### PR TITLE
Use pkg-config to detect system-provided PCRE library #2

### DIFF
--- a/build/make/Makefile.GNU
+++ b/build/make/Makefile.GNU
@@ -23,6 +23,12 @@ ifeq ($(shell pkg-config --exists libcurl && echo 1),1)
 	CURL_LIBS = `pkg-config libcurl --libs`
 endif
 
+# libpcre support
+ifeq ($(shell pkg-config --exists libpcre && echo 1),1)
+	PCRE_CFLAGS = `pkg-config libpcre --cflags`
+	PCRE_LIBS = `pkg-config libpcre --libs`
+endif
+
 USE_ASM=-Did386
 ifeq ($(WITH_OPTIMIZED_CFLAGS),YES)
 	ifeq ($(ARCH),x86)
@@ -65,6 +71,13 @@ ifdef CURL_CFLAGS
 	CFLAGS += $(CURL_CFLAGS)
 	CFLAGS += -DWWW_INTEGRATION
 	LDFLAGS += $(CURL_LIBS)
+endif
+
+ifdef PCRE_CFLAGS
+	CFLAGS += $(PCRE_CFLAGS)
+	LDFLAGS += $(PCRE_LIBS)
+else
+	CFLAGS += -I$(SV_DIR)/pcre
 endif
 
 ifeq ($(CC_BASEVERSION),4) # if gcc4 then build universal binary
@@ -126,13 +139,16 @@ SV_OBJS += \
 		$(SV_DIR)/sha1.o \
 		$(SV_DIR)/build.o \
 		$(SV_DIR)/world.o \
-		$(SV_DIR)/zone.o \
-\
-		$(SV_DIR)/pcre/get.o \
-		$(SV_DIR)/pcre/pcre.o \
+		$(SV_DIR)/zone.o
 
 ifdef CURL_CFLAGS
 		SV_WEB_INTEGRATION = $(SV_DIR)/central.o
+endif
+
+ifndef PCRE_CFLAGS
+	SV_OBJS += \
+		$(SV_DIR)/pcre/get.o \
+		$(SV_DIR)/pcre/pcre.o
 endif
 
 ifeq ($(USE_ASM),$(ASM))
@@ -172,4 +188,4 @@ mvdsv : $(SV_WEB_INTEGRATION) $(SV_OBJS) $(SV_ASM_OBJS)
 
 clean : 
 	$(E) [CLEAN]
-	$(Q)-rm -f $(SV_DIR)/core $(SV_DIR)/*.o $(SV_DIR)/pcre/*.o mvdsv
+	$(Q)-rm -f $(SV_DIR)/core $(SV_OBJS) mvdsv

--- a/meson.build
+++ b/meson.build
@@ -56,11 +56,13 @@ deps = [
 pcre = dependency('libpcre', required : false)
 if pcre.found()
 	deps += pcre
+	inc_dir = include_directories('')
 else
 	mvdsv_sources += [
 		'src/pcre/get.c',
 		'src/pcre/pcre.c'
 	]
+	inc_dir = include_directories('src/pcre')
 endif
 
 curl = dependency('libcurl', required : false)
@@ -116,5 +118,6 @@ endif
 executable('mvdsv', mvdsv_sources,
 	dependencies : deps,
 	c_args : c_args,
-	link_args : link_args
+	link_args : link_args,
+	include_directories: inc_dir
 )

--- a/src/qwsvdef.h
+++ b/src/qwsvdef.h
@@ -83,7 +83,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "version.h"
 
-#include "pcre/pcre.h"
+#include <pcre.h>
 
 //=============================================================================
 

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "qwsvdef.h"
 #ifndef SERVERONLY
-#include "pcre.h"
+#include <pcre.h>
 #endif
 
 static char chartbl[256];

--- a/src/sv_mod_frags.c
+++ b/src/sv_mod_frags.c
@@ -29,7 +29,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "qwsvdef.h"
 #ifndef SERVERONLY
-#include "pcre.h"
+#include <pcre.h>
 #endif
 #include "sv_mod_frags.h"
 


### PR DESCRIPTION
I've also fixed the meson.build to work similar to hillu's patch. It might make sense in the long run to remove all but one build systems, to keep the complexity low.