### PR TITLE
Remove dangerous localcommand

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1087,7 +1087,6 @@ void SV_SetClientConnectionTime(client_t* client);
 #ifdef SERVERONLY
 // mvdsv not changed over to enums yet, which was more about documentation
 #define SV_CommandLineEnableCheats() (COM_CheckParm("-cheats"))
-#define SV_CommandLineEnableLocalCommand() (COM_CheckParm("-enablelocalcommand"))
 #define SV_CommandLineDemoCacheArgument() (COM_CheckParm("-democache"))
 #define SV_CommandLineProgTypeArgument() (COM_CheckParm("-progtype"))
 #define SV_CommandLineUseMinimumMemory() (COM_CheckParm("-minmemory"))
@@ -1095,7 +1094,6 @@ void SV_SetClientConnectionTime(client_t* client);
 #define SV_CommandLineHeapSizeMemoryMB() (COM_CheckParm("-mem"))
 #else
 #define SV_CommandLineEnableCheats() (COM_CheckParm(cmdline_param_server_enablecheats))
-#define SV_CommandLineEnableLocalCommand() (COM_CheckParm(cmdline_param_server_enablelocalcommand))
 #define SV_CommandLineDemoCacheArgument() (COM_CheckParm(cmdline_param_server_democache_kb))
 #define SV_CommandLineProgTypeArgument() (COM_CheckParm(cmdline_param_server_progtype))
 #define SV_CommandLineUseMinimumMemory() (COM_CheckParm(cmdline_param_host_memory_minimum))

--- a/src/sv_ccmds.c
+++ b/src/sv_ccmds.c
@@ -738,54 +738,6 @@ void SV_ChmodFile_f (void)
 }
 #endif //_WIN32
 
-/*==================
-SV_LocalCommand_f
-Execute system command
-==================*/
-//bliP: REMOVE ME REMOVE ME REMOVE ME REMOVE ME REMOVE ME ->
-void SV_LocalCommand_f (void)
-{
-	int i, c;
-	char str[1024], *temp_file = "__output_temp_file__";
-
-	if ((c = Cmd_Argc()) < 2)
-	{
-		Con_Printf("localcommand [command]\n");
-		return;
-	}
-
-	str[0] = 0;
-	for (i = 1; i < c; i++)
-	{
-		strlcat (str, Cmd_Argv(i), sizeof(str));
-		strlcat (str, " ", sizeof(str));
-	}
-	strlcat (str, va("> %s 2>&1\n", temp_file), sizeof(str));
-
-	if (system(str) == -1)
-		Con_Printf("command failed\n");
-	else
-	{
-		char	buf[512];
-		FILE	*f;
-		if ((f = fopen(temp_file, "rt")) == NULL)
-			Con_Printf("(empty)\n");
-		else
-		{
-			while (!feof(f))
-			{
-				buf[fread (buf, 1, sizeof(buf) - 1, f)] = 0;
-				Con_Printf("%s", buf);
-			}
-			fclose(f);
-			if (Sys_remove(temp_file))
-				Con_Printf("Unable to remove file %s\n", temp_file);
-		}
-	}
-
-}
-//REMOVE ME REMOVE ME REMOVE ME REMOVE ME REMOVE ME
-
 /*
 ==================
 SV_Kick_f
@@ -1844,8 +1796,6 @@ void SV_InitOperatorCommands (void)
 	Cmd_AddCommand ("chmod", SV_ChmodFile_f);
 #endif //_WIN32
 	//<-
-	if (SV_CommandLineEnableLocalCommand())
-		Cmd_AddCommand ("localcommand", SV_LocalCommand_f);
 
 	Cmd_AddCommand ("map", SV_Map_f);
 #ifdef SERVERONLY


### PR DESCRIPTION
This pull request removes the dangerous `localcommand` function from the code. It's very insecure and could be potentially open to abuse.