### PR TITLE
MESON: add option to force internal pcre files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,11 @@ deps = [
 	dependency('threads')
 ]
 
-pcre = dependency('libpcre', required : false)
+pcre = disabler()
+if not get_option('force_internal_pcre')
+	pcre = dependency('libpcre', required : false)
+endif
+
 if pcre.found()
 	deps += pcre
 else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('force_internal_pcre', type : 'boolean', value : false)


### PR DESCRIPTION
Use `-Dforce_internal_pcre=true` when invoking meson.

E.g.
```
meson -Dforce_internal_pcre=true build
```