### PR TITLE
meson: drop the use of internal vendored pcre, in favor of wraps

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,11 +56,7 @@ deps = [
 	dependency('threads')
 ]
 
-pcre = disabler()
-if not get_option('force_internal_pcre')
-	pcre = dependency('libpcre', required : false)
-endif
-
+pcre = dependency('libpcre', required : false)
 if pcre.found()
 	deps += pcre
 else

--- a/meson.build
+++ b/meson.build
@@ -53,18 +53,9 @@ c_args = ['-DSERVERONLY', '-DUSE_PR2']
 link_args = []
 
 deps = [
-	dependency('threads')
+	dependency('threads'),
+	dependency('libpcre', default_options: ['default_library=static'])
 ]
-
-pcre = dependency('libpcre', required : false)
-if pcre.found()
-	deps += pcre
-else
-	mvdsv_sources += [
-		'src/pcre/get.c',
-		'src/pcre/pcre.c'
-	]
-endif
 
 curl = dependency('libcurl', required : false)
 if curl.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,0 @@
-option('force_internal_pcre', type : 'boolean', value : false)

--- a/subprojects/pcre.wrap
+++ b/subprojects/pcre.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = pcre-8.37
+source_url = https://sourceforge.net/projects/pcre/files/pcre/8.37/pcre-8.37.tar.bz2
+source_filename = pcre-8.37.tar.bz2
+source_hash = 51679ea8006ce31379fb0860e46dd86665d864b5020fc9cd19e71260eef4789d
+patch_filename = pcre_8.37-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/pcre_8.37-3/get_patch
+patch_hash = a6c6f1bf1c0c4f30b9d79dd6eba1b375c77931a57af69b4a22325a88ebbbb1ff
+
+[provide]
+libpcre = pcre_dep
+

--- a/tools/cross-compilation/linux-aarch64.txt
+++ b/tools/cross-compilation/linux-aarch64.txt
@@ -1,8 +1,8 @@
 [binaries]
 c = 'aarch64-linux-gnu-gcc'
-cpp = 'aarch64-linux-gnu-cpp'
-ar = 'aarch64-linux-gnu-gcc'
-strip = 'aarch64-linux-gnu-gcc'
+cpp = 'aarch64-linux-gnu-g++'
+ar = 'aarch64-linux-gnu-gcc-ar'
+strip = 'aarch64-linux-gnu-strip'
 pkgconfig = 'aarch64-linux-gnu-pkg-config'
 
 [host_machine]


### PR DESCRIPTION
Wrap file installed by running the command:

```
meson wrap install pcre
```

Meson will automatically use the system copy of libpcre, if it can find it, and otherwise fall back to using the wrap, which is much more up to date than the vendored sources.

Users who prefer building a private, statically linked copy of pcre, even if a system copy is available, can do so by configuring meson with --wrap-mode=forcefallback.

Fixes #78