### PR TITLE
BUILD: On CI add meson option -Dwrap_mode=forcefallback

### DIFF
--- a/.github/workflows/build-all-targets.yml
+++ b/.github/workflows/build-all-targets.yml
@@ -24,7 +24,7 @@ jobs:
              pip3 install -r requirements.txt
       - name: Build
         run: |
-             ./.venv/bin/meson build-${{ matrix.target }} --buildtype=release --cross-file tools/cross-compilation/${{ matrix.target }}.txt
+             ./.venv/bin/meson build-${{ matrix.target }} --buildtype=release -Dwrap_mode=forcefallback --cross-file tools/cross-compilation/${{ matrix.target }}.txt
              ninja -v -C build-${{ matrix.target }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The whole idea of this pcre change was to have official builds
having pcre linked statically.