### PR TITLE
PATHS: fix for demo names that contain multiple periods in a row

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -139,7 +139,7 @@ static const char *FS_GetCleanPath(const char *pattern, char *outbuf, int outlen
 			*s = '/';
 	}
 
-	if (*pattern == '/' || strstr(pattern, "..") || strstr(pattern, ":"))
+	if (*pattern == '/' || strstr(pattern, "../") || strstr(pattern, "..\\") || strstr(pattern, ":"))
 		Con_Printf("Error: absolute path in filename %s\n", pattern);
 	else
 		return pattern;


### PR DESCRIPTION
PATHS: when getting a clean path check for ../ and ..\ instead of only .. as these are valid characters in player names and may be contained in demo filenames