### PR TITLE
Add laststats (connectionless packet command) and revert lastscores.

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1008,6 +1008,7 @@ int		Dem_CountTeamPlayers (char *t);
 char	*quote (char *str);
 void	CleanName_Init (void);
 void	SV_LastScores_f (void);
+void	SV_LastStats_f (void);
 void	SV_DemoList_f (void);
 void	SV_DemoListRegex_f (void);
 void	SV_MVDRemove_f (void);

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -1036,13 +1036,13 @@ void SV_LastScores_f (void)
 #define STATS_LIMIT_MAX     50
 void SV_LastStats_f (void)
 {
-	int		limit = STATS_LIMIT_DEFAULT;
-	int		i;
-	char	buf[512];
-	FILE	*f = NULL;
-	char	path[MAX_OSPATH];
-	dir_t	dir;
-	extern	redirect_t sv_redirected;
+	int limit = STATS_LIMIT_DEFAULT;
+	int i;
+	char buf[512];
+	FILE *f = NULL;
+	char path[MAX_OSPATH];
+	dir_t dir;
+	extern redirect_t sv_redirected;
 
 	if (sv_redirected != RD_PACKET)
 	{

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -968,9 +968,7 @@ void SV_MVDInfo_f (void)
 #define MAXDEMOS_RD_PACKET	100
 void SV_LastScores_f (void)
 {
-	int		demos = MAXDEMOS;
-	int 	i;
-	int		nChars;
+	int		demos = MAXDEMOS, i;
 	char	buf[512];
 	FILE	*f = NULL;
 	char	path[MAX_OSPATH];
@@ -980,71 +978,62 @@ void SV_LastScores_f (void)
 	if (Cmd_Argc() > 2)
 	{
 		Con_Printf("usage: lastscores [<numlastdemos>]\n<numlastdemos> = '0' for all demos\n<numlastdemos> = '' for last %i demos\n", MAXDEMOS);
-
 		return;
 	}
 
 	if (Cmd_Argc() == 2)
-	{
 		if ((demos = Q_atoi(Cmd_Argv(1))) <= 0)
-		{
 			demos = MAXDEMOS;
-		}
-	}
 
-	dir = Sys_listdir(va("%s/%s", fs_gamedir, sv_demoDir.string), sv_demoRegexp.string,
-			SORT_BY_DATE);
+	dir = Sys_listdir(va("%s/%s", fs_gamedir, sv_demoDir.string),
+	                  sv_demoRegexp.string, SORT_BY_DATE);
 	if (!dir.numfiles)
 	{
 		Con_Printf("No demos.\n");
-
 		return;
 	}
 
 	if (demos > dir.numfiles)
-	{
 		demos = dir.numfiles;
-	}
 
 	if (demos > MAXDEMOS && GameStarted())
-	{
 		Con_Printf("<numlastdemos> was decreased to %i: match is in progress.\n",
-				demos = MAXDEMOS);
-	}
+					demos = MAXDEMOS);
 
 	if (demos > MAXDEMOS_RD_PACKET && sv_redirected == RD_PACKET)
-	{
 		Con_Printf("<numlastdemos> was decreased to %i: command from connectionless packet.\n",
 					demos = MAXDEMOS_RD_PACKET);
-	}
 
 	Con_Printf("List of %d last demos:\n", demos);
 
-	for (i = dir.numfiles - demos; i < dir.numfiles; i++)
+	for (i = dir.numfiles - demos; i < dir.numfiles; )
 	{
 		snprintf(path, MAX_OSPATH, "%s/%s/%s", fs_gamedir, sv_demoDir.string,
 					SV_MVDName2Txt(dir.files[i].name));
 
+		Con_Printf("%i. ", ++i);
 		if ((f = fopen(path, "rt")) == NULL)
-		{
 			Con_Printf("(empty)\n");
-		}
 		else
 		{
-			while (fread(buf, 1, sizeof(buf)-1, f))
+			if (!feof(f))
 			{
-				Con_Printf("%s", (unsigned char*)buf);
-				memset(buf, 0, sizeof(buf));
+				char *nl;
+
+				buf[fread (buf, 1, sizeof(buf) - 1, f)] = 0;
+				if ((nl = strchr(buf, '\n')))
+					nl[0] = 0;
+				Con_Printf("%s\n", Q_yelltext((unsigned char*)buf));
 			}
-
-			Con_Printf("\n");
-
+			else
+				Con_Printf("(empty)\n");
 			fclose(f);
 		}
 	}
 }
 
 // easyrecord helpers
+
 int Dem_CountPlayers (void)
 {
 	int	i, count;

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -1036,17 +1036,17 @@ void SV_LastScores_f (void)
 #define STATS_LIMIT_MAX     50
 void SV_LastStats_f (void)
 {
-    int     limit = STATS_LIMIT_DEFAULT;
-	int 	i;
+	int		limit = STATS_LIMIT_DEFAULT;
+	int		i;
 	char	buf[512];
 	FILE	*f = NULL;
 	char	path[MAX_OSPATH];
 	dir_t	dir;
-	extern  redirect_t sv_redirected;
+	extern	redirect_t sv_redirected;
 
 	if (sv_redirected != RD_PACKET)
 	{
-	    return;
+		return;
 	}
 
 	if (Cmd_Argc() > 2)
@@ -1056,7 +1056,7 @@ void SV_LastStats_f (void)
 	}
 	else if (Cmd_Argc() == 2)
 	{
-	    limit = Q_atoi(Cmd_Argv(1));
+		limit = Q_atoi(Cmd_Argv(1));
 
 		if (limit <= 0 || limit > STATS_LIMIT_MAX)
 		{
@@ -1069,8 +1069,8 @@ void SV_LastStats_f (void)
 
 	if (!dir.numfiles)
 	{
-	    Con_Printf("laststats 0:\n");
-	    Con_Printf("[]\n");
+		Con_Printf("laststats 0:\n");
+		Con_Printf("[]\n");
 		return;
 	}
 
@@ -1079,7 +1079,7 @@ void SV_LastStats_f (void)
 		limit = dir.numfiles;
 	}
 
-    Con_Printf("laststats %i\n", limit);
+	Con_Printf("laststats %i\n", limit);
 	Con_Printf("[\n");
 
 	for (i = dir.numfiles - limit; i < dir.numfiles; i++)
@@ -1089,10 +1089,10 @@ void SV_LastStats_f (void)
 
 		if ((f = fopen(path, "rt")) != NULL)
 		{
-		    if (i != dir.numfiles - limit)
-		    {
-		        Con_Printf(",\n");
-		    }
+			if (i != dir.numfiles - limit)
+			{
+				Con_Printf(",\n");
+			}
 
 			while (fread(buf, 1, sizeof(buf)-1, f))
 			{

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -1032,6 +1032,80 @@ void SV_LastScores_f (void)
 	}
 }
 
+#define STATS_LIMIT_DEFAULT 10
+#define STATS_LIMIT_MAX     50
+void SV_LastStats_f (void)
+{
+    int     limit = STATS_LIMIT_DEFAULT;
+	int 	i;
+	char	buf[512];
+	FILE	*f = NULL;
+	char	path[MAX_OSPATH];
+	dir_t	dir;
+	extern  redirect_t sv_redirected;
+
+	if (sv_redirected != RD_PACKET)
+	{
+	    return;
+	}
+
+	if (Cmd_Argc() > 2)
+	{
+		Con_Printf("usage: laststats [<limit>]\n<limit> = '0' for last %i stats\n<limit> = 'n' for last n stats (max %i)\n<limit> = '' (empty) for last %i stats\n", STATS_LIMIT_MAX, STATS_LIMIT_MAX, STATS_LIMIT_DEFAULT);
+		return;
+	}
+	else if (Cmd_Argc() == 2)
+	{
+	    limit = Q_atoi(Cmd_Argv(1));
+
+		if (limit <= 0 || limit > STATS_LIMIT_MAX)
+		{
+			limit = STATS_LIMIT_MAX;
+		}
+	}
+
+	dir = Sys_listdir(va("%s/%s", fs_gamedir, sv_demoDir.string), sv_demoRegexp.string,
+			SORT_BY_DATE);
+
+	if (!dir.numfiles)
+	{
+	    Con_Printf("laststats 0:\n");
+	    Con_Printf("[]\n");
+		return;
+	}
+
+	if (limit > dir.numfiles)
+	{
+		limit = dir.numfiles;
+	}
+
+    Con_Printf("laststats %i\n", limit);
+	Con_Printf("[\n");
+
+	for (i = dir.numfiles - limit; i < dir.numfiles; i++)
+	{
+		snprintf(path, MAX_OSPATH, "%s/%s/%s", fs_gamedir, sv_demoDir.string,
+					SV_MVDName2Txt(dir.files[i].name));
+
+		if ((f = fopen(path, "rt")) != NULL)
+		{
+		    if (i != dir.numfiles - limit)
+		    {
+		        Con_Printf(",\n");
+		    }
+
+			while (fread(buf, 1, sizeof(buf)-1, f))
+			{
+				Con_Printf("%s", (unsigned char*)buf);
+				memset(buf, 0, sizeof(buf));
+			}
+			fclose(f);
+		}
+	}
+
+	Con_Printf("\n]\n");
+}
+
 // easyrecord helpers
 
 int Dem_CountPlayers (void)

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -681,6 +681,22 @@ static void SVC_LastScores (void)
 
 /*
 ===================
+SVC_LastStats
+===================
+*/
+void SV_LastStats_f (void);
+static void SVC_LastStats (void)
+{
+	if(!(int)sv_allowlastscores.value)
+		return;
+
+	SV_BeginRedirect (RD_PACKET);
+	SV_LastStats_f ();
+	SV_EndRedirect ();
+}
+
+/*
+===================
 SVC_DemoList
 SVC_DemoListRegex
 ===================
@@ -1893,6 +1909,8 @@ static void SV_ConnectionlessPacket (void)
 		SVC_GetChallenge ();
 	else if (!strcmp(c,"lastscores"))
 		SVC_LastScores ();
+	else if (!strcmp(c,"laststats"))
+		SVC_LastStats ();
 	else if (!strcmp(c,"dlist"))
 		SVC_DemoList ();
 	else if (!strcmp(c,"dlistr"))


### PR DESCRIPTION
**Usage**
```
laststats [<limit>]

<limit> = '0' for last 50 stats
<limit> = 'n' for last n stats (max 50)
<limit> = '' (empty) for last 10 stats
```

**Response**

results found
```
laststats <NUMBER_OF_RESULTS>
[
  <STAT_ENTRY_JSON_BLOB>,
  <STAT_ENTRY_JSON_BLOB>,
  [...]
]
```

no results found:
```
laststats 0
[]
```