### PR TITLE
BSP: Reduce memory during loadmap.

### DIFF
--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -1122,7 +1122,7 @@ static void CM_BuildPVS(byte *visdata, int vis_len, byte *leaf_buf, int leaf_len
 
 	map_vis_rowlongs = (visleafs + 31) >> 5;
 	map_vis_rowbytes = map_vis_rowlongs * 4;
-	map_pvs = (byte *)Hunk_Alloc(map_vis_rowbytes * visleafs);
+	map_pvs = (byte *)Hunk_AllocName(map_vis_rowbytes * visleafs, "pvs");
 
 	if (!vis_len) {
 		memset(map_pvs, 0xff, map_vis_rowbytes * visleafs);
@@ -1149,7 +1149,7 @@ static void CM_BuildPVS29a(byte *visdata, int vis_len, byte *leaf_buf, int leaf_
 
 	map_vis_rowlongs = (visleafs + 31) >> 5;
 	map_vis_rowbytes = map_vis_rowlongs * 4;
-	map_pvs = (byte *)Hunk_Alloc(map_vis_rowbytes * visleafs);
+	map_pvs = (byte *)Hunk_AllocName(map_vis_rowbytes * visleafs, "pvs");
 
 	if (!vis_len) {
 		memset(map_pvs, 0xff, map_vis_rowbytes * visleafs);
@@ -1176,7 +1176,7 @@ static void CM_BuildPVSBSP2(byte *visdata, int vis_len, byte *leaf_buf, int leaf
 
 	map_vis_rowlongs = (visleafs + 31) >> 5;
 	map_vis_rowbytes = map_vis_rowlongs * 4;
-	map_pvs = (byte *)Hunk_Alloc(map_vis_rowbytes * visleafs);
+	map_pvs = (byte *)Hunk_AllocName(map_vis_rowbytes * visleafs, "pvs");
 
 	if (!vis_len) {
 		memset(map_pvs, 0xff, map_vis_rowbytes * visleafs);
@@ -1212,7 +1212,7 @@ static void CM_BuildPHS (void)
 		return;
 	}
 
-	map_phs = (byte *) Hunk_Alloc (map_vis_rowbytes * visleafs);
+	map_phs = (byte *) Hunk_AllocName (map_vis_rowbytes * visleafs, "phs");
 	scan = map_pvs;
 	dest = (unsigned *)map_phs;
 	for (i = 0; i < visleafs; i++, dest += map_vis_rowlongs, scan += map_vis_rowbytes)

--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -1377,6 +1377,7 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 
 	COM_FileBase (name, loadname);
 
+	// Flush to temp zone to leave as much heap available to map loading as possible.
 	Hunk_TempFlush();
 
 	l_planes = CM_ReadLump(vf, &header.lumps[LUMP_PLANES]);
@@ -1426,6 +1427,7 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 
 	strlcpy (map_name, name, sizeof(map_name));
 
+	// Flush temp zone to leave as much heap available to mods as possible.
 	Hunk_TempFlush();
 
 	return &map_cmodels[0];

--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -599,14 +599,14 @@ int CM_FindTouchedLeafs (const vec3_t mins, const vec3_t maxs, int leafs[], int 
 ===============================================================================
 */
 
-static void CM_LoadEntities (lump_t *l)
+static void CM_LoadEntities (byte *buffer, int length)
 {
-	if (!l->filelen) {
+	if (!length) {
 		map_entitystring = NULL;
 		return;
 	}
-	map_entitystring = (char *) Hunk_AllocName (l->filelen, loadname);
-	memcpy (map_entitystring, cmod_base + l->fileofs, l->filelen);
+	map_entitystring = (char *) Hunk_AllocName (length, loadname);
+	memcpy (map_entitystring, buffer, length);
 }
 
 
@@ -1376,7 +1376,7 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 	int required_length = 0;
 	int filelen = 0;
 	vfsfile_t *vf;
-	byte *l_planes, *l_leafs, *l_nodes, *l_clipnodes;
+	byte *l_planes, *l_leafs, *l_nodes, *l_clipnodes, *l_entities;
 
 	if (map_name[0]) {
 		assert(!strcmp(name, map_name));
@@ -1447,6 +1447,7 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 	l_leafs = CM_ReadLump(vf, &header.lumps[LUMP_LEAFS]);
 	l_nodes = CM_ReadLump(vf, &header.lumps[LUMP_NODES]);
 	l_clipnodes = CM_ReadLump(vf, &header.lumps[LUMP_CLIPNODES]);
+	l_entities = CM_ReadLump(vf, &header.lumps[LUMP_ENTITIES]);
 
 	// load into heap
 	CM_LoadPlanes (l_planes, header.lumps[LUMP_PLANES].filelen);
@@ -1468,7 +1469,7 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 		CM_LoadClipnodes(l_clipnodes, header.lumps[LUMP_CLIPNODES].filelen);
 		cm_load_pvs_func = CM_BuildPVS;
 	}
-	CM_LoadEntities (&header.lumps[LUMP_ENTITIES]);
+	CM_LoadEntities (l_entities, header.lumps[LUMP_ENTITIES].filelen);
 	CM_LoadSubmodels (&header.lumps[LUMP_MODELS]);
 
 	CM_LoadPhysicsNormals(filelen);

--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -790,17 +790,17 @@ static void CM_LoadNodesBSP2(lump_t *l)
 /*
 ** CM_LoadLeafs
 */
-static void CM_LoadLeafs (lump_t *l)
+static void CM_LoadLeafs (byte *buffer, int length)
 {
 	dleaf_t *in;
 	cleaf_t *out;
 	int i, j, count, p;
 
-	in = (dleaf_t *)(cmod_base + l->fileofs);
+	in = (dleaf_t *) buffer;
 
-	if (l->filelen % sizeof(*in))
+	if (length % sizeof(*in))
 		Host_Error ("CM_LoadMap: funny lump size");
-	count = l->filelen / sizeof(*in);
+	count = length / sizeof(*in);
 	out = (cleaf_t *) Hunk_AllocName ( count*sizeof(*out), loadname);
 
 	map_leafs = out;
@@ -814,19 +814,19 @@ static void CM_LoadLeafs (lump_t *l)
 	}
 }
 
-static void CM_LoadLeafs29a (lump_t *l)
+static void CM_LoadLeafs29a (byte *buffer, int length)
 {
 	dleaf29a_t *in;
 
 	cleaf_t *out;
 	int i, j, count, p;
 
-	in = (dleaf29a_t *)(cmod_base + l->fileofs);
-	if (l->filelen % sizeof(*in)) {
+	in = (dleaf29a_t *) buffer;
+	if (length % sizeof(*in)) {
 		Host_Error("CM_LoadMap: funny lump size");
 	}
 
-	count = l->filelen / sizeof(*in);
+	count = length / sizeof(*in);
 	out = Hunk_AllocName ( count*sizeof(*out), loadname);
 
 	map_leafs = out;
@@ -841,20 +841,20 @@ static void CM_LoadLeafs29a (lump_t *l)
 
 }
 
-static void CM_LoadLeafsBSP2 (lump_t *l)
+static void CM_LoadLeafsBSP2 (byte *buffer, int length)
 {
 	dleaf_bsp2_t *in;
 
 	cleaf_t *out;
 	int i, j, count, p;
 
-	in = (dleaf_bsp2_t *)(cmod_base + l->fileofs);
+	in = (dleaf_bsp2_t *) buffer;
 
-	if (l->filelen % sizeof(*in)) {
+	if (length % sizeof(*in)) {
 		Host_Error("CM_LoadMap: funny lump size");
 	}
 
-	count = l->filelen / sizeof(*in);
+	count = length / sizeof(*in);
 	out = Hunk_AllocName ( count*sizeof(*out), loadname);
 
 	map_leafs = out;
@@ -1376,7 +1376,7 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 	int required_length = 0;
 	int filelen = 0;
 	vfsfile_t *vf;
-	byte *l_planes;
+	byte *l_planes, *l_leafs;
 
 	if (map_name[0]) {
 		assert(!strcmp(name, map_name));
@@ -1444,23 +1444,24 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 	cmod_base = (byte *) buf;
 
 	l_planes = CM_ReadLump(vf, &header.lumps[LUMP_PLANES]);
+	l_leafs = CM_ReadLump(vf, &header.lumps[LUMP_LEAFS]);
 
 	// load into heap
 	CM_LoadPlanes (l_planes, header.lumps[LUMP_PLANES].filelen);
 	if (LittleLong(header.version) == Q1_BSPVERSION29a) {
-		CM_LoadLeafs29a(&header.lumps[LUMP_LEAFS]);
+		CM_LoadLeafs29a(l_leafs, header.lumps[LUMP_LEAFS].filelen);
 		CM_LoadNodes29a(&header.lumps[LUMP_NODES]);
 		CM_LoadClipnodesBSP2(&header.lumps[LUMP_CLIPNODES]);
 		cm_load_pvs_func = CM_BuildPVS29a;
 	}
 	else if (LittleLong(header.version) == Q1_BSPVERSION2) {
-		CM_LoadLeafsBSP2(&header.lumps[LUMP_LEAFS]);
+		CM_LoadLeafsBSP2(l_leafs, header.lumps[LUMP_LEAFS].filelen);
 		CM_LoadNodesBSP2(&header.lumps[LUMP_NODES]);
 		CM_LoadClipnodesBSP2(&header.lumps[LUMP_CLIPNODES]);
 		cm_load_pvs_func = CM_BuildPVSBSP2;
 	}
 	else {
-		CM_LoadLeafs(&header.lumps[LUMP_LEAFS]);
+		CM_LoadLeafs(l_leafs, header.lumps[LUMP_LEAFS].filelen);
 		CM_LoadNodes(&header.lumps[LUMP_NODES]);
 		CM_LoadClipnodes(&header.lumps[LUMP_CLIPNODES]);
 		cm_load_pvs_func = CM_BuildPVS;

--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -1350,6 +1350,17 @@ static void CM_CalcChecksum(vfsfile_t *f, dheader_t *header, unsigned *checksum,
 		*checksum2 = map_checksum2;
 }
 
+static byte *CM_ReadLump(vfsfile_t *vf, lump_t *lump)
+{
+	byte *out;
+
+	VFS_SEEK(vf, lump->fileofs, SEEK_SET);
+	out = Hunk_TempAllocMore(lump->filelen);
+	VFS_READ(vf, out, lump->filelen, NULL);
+
+	return out;
+}
+
 /*
 ** CM_LoadMap
 */

--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -615,18 +615,18 @@ static void CM_LoadEntities (byte *buffer, int length)
 CM_LoadSubmodels
 =================
 */
-static void CM_LoadSubmodels (lump_t *l)
+static void CM_LoadSubmodels (byte *buffer, int length)
 {
 	dmodel_t *in;
 	cmodel_t *out;
 	int i, j, count;
 
-	in = (dmodel_t *)(cmod_base + l->fileofs);
+	in = (dmodel_t *) buffer;
 
-	if (l->filelen % sizeof(*in))
+	if (length % sizeof(*in))
 		Host_Error ("CM_LoadMap: funny lump size");
 
-	count = l->filelen / sizeof(*in);
+	count = length / sizeof(*in);
 
 	if (count < 1)
 		Host_Error ("Map with no models");
@@ -1376,7 +1376,7 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 	int required_length = 0;
 	int filelen = 0;
 	vfsfile_t *vf;
-	byte *l_planes, *l_leafs, *l_nodes, *l_clipnodes, *l_entities;
+	byte *l_planes, *l_leafs, *l_nodes, *l_clipnodes, *l_entities, *l_models;
 
 	if (map_name[0]) {
 		assert(!strcmp(name, map_name));
@@ -1448,6 +1448,7 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 	l_nodes = CM_ReadLump(vf, &header.lumps[LUMP_NODES]);
 	l_clipnodes = CM_ReadLump(vf, &header.lumps[LUMP_CLIPNODES]);
 	l_entities = CM_ReadLump(vf, &header.lumps[LUMP_ENTITIES]);
+	l_models = CM_ReadLump(vf, &header.lumps[LUMP_MODELS]);
 
 	// load into heap
 	CM_LoadPlanes (l_planes, header.lumps[LUMP_PLANES].filelen);
@@ -1470,7 +1471,7 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 		cm_load_pvs_func = CM_BuildPVS;
 	}
 	CM_LoadEntities (l_entities, header.lumps[LUMP_ENTITIES].filelen);
-	CM_LoadSubmodels (&header.lumps[LUMP_MODELS]);
+	CM_LoadSubmodels (l_models, header.lumps[LUMP_MODELS].filelen);
 
 	CM_LoadPhysicsNormals(filelen);
 	CM_MakeHull0 ();

--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -84,9 +84,6 @@ typedef struct {
 	int filelen;
 } bspx_lump_t;
 
-void* Mod_BSPX_FindLump(bspx_header_t* bspx_header, char* lumpname, int* plumpsize, byte* mod_base);
-bspx_header_t* Mod_LoadBSPX(int filesize, byte* mod_base);
-
 static bspx_lump_t* CM_LoadBSPX(vfsfile_t* vf, dheader_t* header, bspx_header_t *xheader);
 static byte* CM_BSPX_ReadLump(vfsfile_t* vf, bspx_header_t *xheader, bspx_lump_t* lump, char* lumpname, int* plumpsize);
 
@@ -1526,6 +1523,7 @@ static qbool CM_BSPX_LoadLumps(bspx_lump_t *lump, int numlumps, int filesize)
     return true;
 }
 
+#ifndef SERVERONLY
 // Used by ezquake
 void* Mod_BSPX_FindLump(bspx_header_t* bspx_header, char* lumpname, int* plumpsize, byte* mod_base)
 {
@@ -1579,6 +1577,7 @@ bspx_header_t* Mod_LoadBSPX(int filesize, byte* mod_base)
 	// success
 	return xheader;
 }
+#endif
 
 static byte* CM_BSPX_ReadLump(vfsfile_t *vf, bspx_header_t *xheader, bspx_lump_t* lump, char* lumpname, int* plumpsize)
 {

--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -1380,6 +1380,8 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 
 	COM_FileBase (name, loadname);
 
+	Hunk_TempFlush();
+
 	l_planes = CM_ReadLump(vf, &header.lumps[LUMP_PLANES]);
 	l_leafs = CM_ReadLump(vf, &header.lumps[LUMP_LEAFS]);
 	l_nodes = CM_ReadLump(vf, &header.lumps[LUMP_NODES]);
@@ -1426,6 +1428,8 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 		CM_BuildPHS ();
 
 	strlcpy (map_name, name, sizeof(map_name));
+
+	Hunk_TempFlush();
 
 	return &map_cmodels[0];
 }

--- a/src/cmodel.h
+++ b/src/cmodel.h
@@ -115,7 +115,9 @@ typedef struct bspx_header_s {
 	int numlumps;
 } bspx_header_t;
 
+#ifndef SERVERONLY
 void* Mod_BSPX_FindLump(bspx_header_t* bspx_header, char* lumpname, int* plumpsize, byte* mod_base);
 bspx_header_t* Mod_LoadBSPX(int filesize, byte* mod_base);
+#endif
 
 #endif /* !__CMODEL_H__ */

--- a/src/vfs_pak.c
+++ b/src/vfs_pak.c
@@ -100,6 +100,7 @@ static int VFSPAK_WriteBytes (struct vfsfile_s *vfs, const void *buffer, int byt
 static int VFSPAK_Seek (struct vfsfile_s *vfs, unsigned long offset, int whence)
 {
 	vfspack_t *vfsp = (vfspack_t*)vfs;
+	int rel_offset;
 
 	// VFS-FIXME Support other whence types
 	switch(whence) {
@@ -117,7 +118,8 @@ static int VFSPAK_Seek (struct vfsfile_s *vfs, unsigned long offset, int whence)
 		return -1;
 	}
 
-	if (vfsp->currentpos > vfsp->length) {
+	rel_offset = vfsp->currentpos - vfsp->startpos;
+	if (rel_offset < 0 || rel_offset >= vfsp->length) {
 		Con_Printf("VFSPAK_Seek: Warning seeking past the file's size\n");
 	}
 

--- a/src/zone.c
+++ b/src/zone.c
@@ -278,6 +278,16 @@ static void *Hunk_HighAllocName(int size, char *name)
 	return (void *)(h + 1);
 }
 
+void Hunk_TempFlush()
+{
+	if (hunk_tempactive) {
+		Hunk_FreeToHighMark(hunk_tempmark);
+		hunk_tempactive = false;
+	}
+
+	hunk_tempmark = Hunk_HighMark();
+}
+
 /*
 =================
 Hunk_TempAlloc
@@ -289,12 +299,7 @@ void *Hunk_TempAlloc(int size)
 {
 	void *buf;
 
-	if (hunk_tempactive) {
-		Hunk_FreeToHighMark(hunk_tempmark);
-		hunk_tempactive = false;
-	}
-
-	hunk_tempmark = Hunk_HighMark();
+	Hunk_TempFlush();
 
 	buf = Hunk_HighAllocName(size, "temp");
 
@@ -306,7 +311,7 @@ void *Hunk_TempAlloc(int size)
 void *Hunk_TempAllocMore(int size)
 {
 	if (!hunk_tempactive)
-		Sys_Error("Hunk_TempAllocMore: Must be called after Hunk_TempAlloc.");
+		return Hunk_TempAlloc(size);
 
 	return Hunk_HighAllocName(size, "temp+");
 }

--- a/src/zone.c
+++ b/src/zone.c
@@ -224,7 +224,7 @@ void Hunk_FreeToLowMark(int mark)
 	hunk_low_used = mark;
 }
 
-int	Hunk_HighMark(void)
+static int Hunk_HighMark(void)
 {
 	if (hunk_tempactive) {
 		hunk_tempactive = false;
@@ -234,7 +234,7 @@ int	Hunk_HighMark(void)
 	return hunk_high_used;
 }
 
-void Hunk_FreeToHighMark(int mark)
+static void Hunk_FreeToHighMark(int mark)
 {
 	if (hunk_tempactive) {
 		hunk_tempactive = false;
@@ -252,7 +252,7 @@ void Hunk_FreeToHighMark(int mark)
 Hunk_HighAllocName
 ===================
 */
-void *Hunk_HighAllocName(int size, char *name)
+static void *Hunk_HighAllocName(int size, char *name)
 {
 	hunk_t *h;
 

--- a/src/zone.c
+++ b/src/zone.c
@@ -278,6 +278,13 @@ static void *Hunk_HighAllocName(int size, char *name)
 	return (void *)(h + 1);
 }
 
+/*
+=================
+Hunk_TempFlush
+
+Free the temporary memory zone to baseline.
+=================
+*/
 void Hunk_TempFlush()
 {
 	if (hunk_tempactive) {
@@ -308,6 +315,13 @@ void *Hunk_TempAlloc(int size)
 	return buf;
 }
 
+/*
+=================
+Hunk_TempAllocMore
+
+Return space after any previous temporary allocation without clearing first.
+=================
+*/
 void *Hunk_TempAllocMore(int size)
 {
 	if (!hunk_tempactive)

--- a/src/zone.c
+++ b/src/zone.c
@@ -289,8 +289,6 @@ void *Hunk_TempAlloc(int size)
 {
 	void *buf;
 
-	size = (size + 15) & ~15;
-
 	if (hunk_tempactive) {
 		Hunk_FreeToHighMark(hunk_tempmark);
 		hunk_tempactive = false;

--- a/src/zone.c
+++ b/src/zone.c
@@ -303,6 +303,14 @@ void *Hunk_TempAlloc(int size)
 	return buf;
 }
 
+void *Hunk_TempAllocMore(int size)
+{
+	if (!hunk_tempactive)
+		Sys_Error("Hunk_TempAllocMore: Must be called after Hunk_TempAlloc.");
+
+	return Hunk_HighAllocName(size, "temp+");
+}
+
 #ifdef SERVERONLY
 /*
 ===============================================================================

--- a/src/zone.c
+++ b/src/zone.c
@@ -226,20 +226,11 @@ void Hunk_FreeToLowMark(int mark)
 
 static int Hunk_HighMark(void)
 {
-	if (hunk_tempactive) {
-		hunk_tempactive = false;
-		Hunk_FreeToHighMark(hunk_tempmark);
-	}
-
 	return hunk_high_used;
 }
 
 static void Hunk_FreeToHighMark(int mark)
 {
-	if (hunk_tempactive) {
-		hunk_tempactive = false;
-		Hunk_FreeToHighMark(hunk_tempmark);
-	}
 	if (mark < 0 || mark > hunk_high_used) {
 		Sys_Error("Hunk_FreeToHighMark: bad mark %i", mark);
 	}
@@ -258,11 +249,6 @@ static void *Hunk_HighAllocName(int size, char *name)
 
 	if (size < 0) {
 		Sys_Error("Hunk_HighAllocName: bad size: %i", size);
-	}
-
-	if (hunk_tempactive) {
-		Hunk_FreeToHighMark(hunk_tempmark);
-		hunk_tempactive = false;
 	}
 
 #ifdef PARANOID

--- a/src/zone.h
+++ b/src/zone.h
@@ -88,6 +88,7 @@ void *Hunk_AllocName (int size, const char *name);
 int	Hunk_LowMark (void);
 void Hunk_FreeToLowMark (int mark);
 
+void Hunk_TempFlush();
 void *Hunk_TempAlloc (int size);
 void *Hunk_TempAllocMore(int size);
 

--- a/src/zone.h
+++ b/src/zone.h
@@ -85,13 +85,8 @@ void Memory_Init (void *buf, int size);
 void *Hunk_Alloc (int size); // returns 0 filled memory
 void *Hunk_AllocName (int size, const char *name);
 
-void *Hunk_HighAllocName (int size, char *name);
-
 int	Hunk_LowMark (void);
 void Hunk_FreeToLowMark (int mark);
-
-int	Hunk_HighMark (void);
-void Hunk_FreeToHighMark (int mark);
 
 void *Hunk_TempAlloc (int size);
 

--- a/src/zone.h
+++ b/src/zone.h
@@ -89,6 +89,7 @@ int	Hunk_LowMark (void);
 void Hunk_FreeToLowMark (int mark);
 
 void *Hunk_TempAlloc (int size);
+void *Hunk_TempAllocMore(int size);
 
 void Hunk_Check (void);
 


### PR DESCRIPTION
Read lump by lump instead of allocating memory covering the whole map in the temporary region, and sometimes adding an additional malloc that duplicates the data if lumps are not aligned.

This has become more relevant with mappers including lighting in BSPX lump and higher resolution textures, which isn't relevant to the server, but is still temporarily loaded into the heap before this PR.