### PR TITLE
DOWNLOAD: bump download speed

### DIFF
--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -42,7 +42,7 @@ cvar_t	sv_kickuserinfospamcount = {"sv_kickuserinfospamcount", "300"};
 cvar_t	sv_maxuploadsize = {"sv_maxuploadsize", "1048576"};
 
 #ifdef FTE_PEXT_CHUNKEDDOWNLOADS
-cvar_t  sv_downloadchunksperframe = {"sv_downloadchunksperframe", "2"};
+cvar_t  sv_downloadchunksperframe = {"sv_downloadchunksperframe", "15"};
 #endif
 
 #ifdef FTE_PEXT2_VOICECHAT
@@ -1105,6 +1105,7 @@ void SV_NextChunkedDownload(int chunknum, int percent, int chunked_download_numb
 #define CHUNKSIZE 1024
 	char buffer[CHUNKSIZE];
 	int i;
+	int maxchunks = bound(1, (int)sv_downloadchunksperframe.value, 30);
 
 	sv_client->file_percent = bound(0, percent, 100); //bliP: file percent
 
@@ -1114,13 +1115,9 @@ void SV_NextChunkedDownload(int chunknum, int percent, int chunked_download_numb
 		return;
 	}
 
-	if (sv_client->download_chunks_perframe)
-	{
-		int maxchunks = bound(1, (int)sv_downloadchunksperframe.value, 4);
-		// too much requests or client sent something wrong
-		if (sv_client->download_chunks_perframe >= maxchunks || chunked_download_number < 1)
-			return;
-	}
+	// Check if too much requests or client sent something wrong
+	if (sv_client->download_chunks_perframe >= maxchunks || chunked_download_number < 1)
+		return;
 
 	if (!sv_client->download_chunks_perframe) // ignore "rate" if not first packet per frame
 		if (sv_client->datagram.cursize + CHUNKSIZE+5+50 > sv_client->datagram.maxsize)


### PR DESCRIPTION
Default value for sv_downloadchunksperframe is 15, you can set it up to 30. This shoud allow up to 1024 * 30 * 77 bytes per second download speed. Client should request such amount of chunks per frame though.