### PR TITLE
BUG: use size_t for holding the size of a directory, continue calculating dir size after we've hit file number limit

### DIFF
--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -52,7 +52,7 @@ int	Sys_FileTime (const char *path)
 	return stat(path, &buf) == -1 ? -1 : buf.st_mtime;
 }
 
-int Sys_FileSizeTime (char *path, int *time1)
+int Sys_FileSizeTime (char *path, time_t *time1)
 {
 	struct stat buf;
 	if (stat(path, &buf) == -1)
@@ -179,8 +179,8 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 		}
 		strlcpy (list[dir.numfiles].name, oneentry->d_name, MAX_DEMO_NAME);
 
-		if (++dir.numfiles == MAX_DIRFILES - 1)
-			break;
+		if (dir.numfiles != MAX_DIRFILES - 1) dir.numfiles++;
+
 	}
 	closedir(d);
 	if (!all)

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -231,8 +231,7 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 		}
 		strlcpy (list[dir.numfiles].name, fd.cFileName, sizeof(list[0].name));
 
-		if (++dir.numfiles == MAX_DIRFILES - 1)
-			break;
+		if (dir.numfiles != MAX_DIRFILES - 1) dir.numfiles++;
 
 	}
 	while (FindNextFile(h, &fd));

--- a/src/sys.h
+++ b/src/sys.h
@@ -40,17 +40,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 typedef struct
 {
 	char	name[MAX_DEMO_NAME];
-	int	size;
-	int	time;
+	size_t	size;
+	time_t	time;
 	qbool	isdir; //bliP: list dir
 } file_t;
 
 typedef struct
 {
-	file_t *files;
-	int	size;
-	int	numfiles;
-	int	numdirs;
+	file_t	*files;
+	size_t	size;
+	size_t	numfiles;
+	size_t	numdirs;
 } dir_t;
 
 int		Sys_FileTime (const char *path);


### PR DESCRIPTION
…rflow on larger directories and never clean things up.  this is related to issue #135