### PR TITLE
replace rng seed generation

### DIFF
--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -563,7 +563,7 @@ void PR2_InitProg(void)
 	PR2_FS_Restart();
 
 	gamedata.APIversion = 0;
-	gamedata_ptr = (intptr_t) VM_Call(sv_vm, 2, GAME_INIT, (int)(sv.time * 1000), (int)(Sys_DoubleTime() * 100000), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+	gamedata_ptr = (intptr_t) VM_Call(sv_vm, 2, GAME_INIT, (int)(sv.time * 1000), (int)time(NULL), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 	if (!gamedata_ptr) {
 		SV_Error("PR2_InitProg: gamedata == NULL");
 	}


### PR DESCRIPTION
# Motivation

Duelers were alarmed by an apparent lack of randomness in starting spawns.

Some kind of seeding problem was suspected.

# Investigation

**phylter** and **Zorak** discovered the following:

`Sys_DoubleTime` returns approximate seconds since MVDSV launch.

RNG is seeded with `randomSeed = (int)(Sys_DoubleTime() * 100000)`.

Maximum value `randomSeed` can hold is 2147483647.

`(int)(Sys_DoubleTime() * 100000)` exceeds 2147483647 in just under 6 hours, after which the value stops increasing (or potentially behaves in an undefined way).

The code in question was introduced in 2021 (commit 837bdfcbd5bd061b6f34fec1737bfcfc3d7e58f2).

On affected servers, after 6 hours of uptime, it is possible to lock the starting spawns entirely by minimizing player activity (which can trigger RNG calls) during pre-war.

# Solution

Seed the RNG directly with elapsed seconds since epoch.

Replace
```
(int)(Sys_DoubleTime() * 100000)
```
with
```
(int)time(NULL)
```

This provides a source of unique seeds for a very long time.

# Notes

There is some concern that epoch functions might behave badly in the year 2038 on some old 32-bit machines... the so-called "2038 problem".

We figure such systems, already in the extreme minority, will face much bigger problems than running quakeworld.

Most MVDSV instances are already 64-bit, and are therefore unaffected.

There is a non-epoch alternative worthy of mention (suggested by **foobar**):

Replace
```
(int)(Sys_DoubleTime() * 100000)
```
with something like
```
double t = Sys_DoubleTime();
randomSeed = *(int*)&t;
```
This is elegant but cannot make any guarantees about seeds being unique. Presumably the repeats would be far apart.