### PR TITLE
BUILD: when building windows binaries do not look for libcurl as if i…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,26 +82,22 @@ set(SRC_COMMON
 # Check build target, and included sources
 if(UNIX)
 	list(APPEND SRC_COMMON
-	    "${DIR_SRC}/sv_sys_unix.c"
+		"${DIR_SRC}/sv_sys_unix.c"
 	)
+	# Check for curl, and include sources and libs, if found
+	find_package(CURL)
+	if(NOT CURL_FOUND)
+		message(STATUS "Curl library not found")
+	else()
+		list(APPEND SRC_COMMON
+			"${DIR_SRC}/central.c"
+		)
+	endif()
 else()
 	list(APPEND SRC_COMMON
-	    "${DIR_SRC}/sv_sys_win.c"
-	    "${DIR_SRC}/sv_windows.c"
-	    "${DIR_SRC}/winquake.rc"
-	)
-endif()
-
-
-######################################################################################################
-
-# Check for curl, and include sources and libs, if found
-find_package(CURL)
-if(NOT CURL_FOUND)
-	message(STATUS "Curl library not found")
-else()
-	list(APPEND SRC_COMMON
-	    "${DIR_SRC}/central.c"
+		"${DIR_SRC}/sv_sys_win.c"
+		"${DIR_SRC}/sv_windows.c"
+		"${DIR_SRC}/winquake.rc"
 	)
 endif()
 


### PR DESCRIPTION
…t is found it will attempt to use the native include paths which will break compilation, attempting to use the libcurl.a from debian won't work anyway being that it doesn't actually contain many of the dependencies.