### PR TITLE
CI: Update build to work with newer docker.

### DIFF
--- a/.github/workflows/build-and-deploy-release.yml
+++ b/.github/workflows/build-and-deploy-release.yml
@@ -19,19 +19,19 @@ jobs:
            ext: ""
          - target: linux-i686
            os: linux
-           arch: i686
+           arch: i386
            base-image: ubuntu-latest
            build-image: i386/debian:stable
            ext: ""
          - target: linux-armhf
            os: linux
-           arch: armhf
+           arch: arm/v7
            base-image: ubuntu-latest
            build-image: arm32v7/debian:stable
            ext: ""
          - target: linux-aarch64
            os: linux
-           arch: aarch64
+           arch: arm64
            base-image: ubuntu-latest
            build-image: arm64v8/debian:stable
            ext: ""
@@ -50,27 +50,26 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        if: matrix.os == 'linux'
       - name: Prepare Build Environemnt
         shell: bash
-        run: |
-             if ${{ matrix.os  == 'linux' }}; then
-               sudo apt-get update
-               sudo apt-get -y install qemu-system-arm qemu-user-static
-             else
-               sudo apt-get update
-               sudo apt-get -y install build-essential cmake gcc-i686-linux-gnu
-               sudo apt-get -y install gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-               sudo apt-get -y install gcc-mingw-w64-x86-64 gcc-mingw-w64-i686
-             fi
+        run: sudo apt-get update -qq && sudo apt-get -qq --no-install-recommends install build-essential cmake gcc-mingw-w64-x86-64 gcc-mingw-w64-i686
+        if: matrix.os == 'windows'
       - name: Build
-        shell: bash
         run: |
-             if ${{ matrix.os  == 'linux' }}; then
-               docker pull ${{ matrix.build-image }}
-               docker run --net=host --rm --device /dev/fuse -v $PWD:/mvdsv ${{ matrix.build-image }} bash -c -e 'export ARCH=$(dpkg --print-architecture);export DEBIAN_FRONTEND=noninteractive;mkdir -p /etc/apt/apt.conf.d;echo "APT::Install-Recommends "0"; APT::AutoRemove::RecommendsImportant "false";" >> /etc/apt/apt.conf.d/01lean && apt-get -qqy update && apt-get -qqy dist-upgrade && apt-get -qqy install cmake build-essential libcurl4-openssl-dev && ln -sf "$(which make)" /usr/bin/gmake && cd /mvdsv && ./build_cmake.sh ${{ matrix.target }} && chown -R '$(id -u ${USER})':'$(id -g ${USER})' /mvdsv/build/${{ matrix.target }}||exit 3'
-             else
-               ./build_cmake.sh ${{ matrix.target }}
-             fi
+          if ${{ matrix.os  == 'linux' }}; then
+            docker run --platform linux/${{ matrix.arch }} --net=host --rm --device /dev/fuse -v $PWD:/mvdsv -w /mvdsv ${{ matrix.build-image }} bash -c -e '
+              set -e
+              apt-get -qq update
+              apt-get -qq --no-install-recommends install cmake build-essential libcurl4-openssl-dev ninja-build
+              ./build_cmake.sh ${{ matrix.target }}
+              chown -R '$(id -u ${USER})':'$(id -g ${USER})' build/${{ matrix.target }} || exit 3
+            '
+          else
+            ./build_cmake.sh ${{ matrix.target }}
+          fi
       - name: Create checksum
         run: |
              md5sum build/${{ matrix.target }}/mvdsv${{ matrix.ext }} > build/${{ matrix.target }}/mvdsv.md5

--- a/.github/workflows/build-and-deploy-snapshot.yml
+++ b/.github/workflows/build-and-deploy-snapshot.yml
@@ -17,19 +17,19 @@ jobs:
            ext: ""
          - target: linux-i686
            os: linux
-           arch: i686
+           arch: i386
            base-image: ubuntu-latest
            build-image: i386/debian:stable
            ext: ""
          - target: linux-armhf
            os: linux
-           arch: armhf
+           arch: arm/v7
            base-image: ubuntu-latest
            build-image: arm32v7/debian:stable
            ext: ""
          - target: linux-aarch64
            os: linux
-           arch: aarch64
+           arch: arm64
            base-image: ubuntu-latest
            build-image: arm64v8/debian:stable
            ext: ""
@@ -48,27 +48,26 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        if: matrix.os == 'linux'
       - name: Prepare Build Environemnt
         shell: bash
-        run: |
-             if ${{ matrix.os  == 'linux' }}; then
-               sudo apt-get update
-               sudo apt-get -y install qemu-system-arm qemu-user-static
-             else
-               sudo apt-get update
-               sudo apt-get -y install build-essential cmake gcc-i686-linux-gnu
-               sudo apt-get -y install gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-               sudo apt-get -y install gcc-mingw-w64-x86-64 gcc-mingw-w64-i686
-             fi
+        run: sudo apt-get update -qq && sudo apt-get -qq --no-install-recommends install build-essential cmake gcc-mingw-w64-x86-64 gcc-mingw-w64-i686
+        if: matrix.os == 'windows'
       - name: Build
-        shell: bash
         run: |
-             if ${{ matrix.os  == 'linux' }}; then
-               docker pull ${{ matrix.build-image }}
-               docker run --net=host --rm --device /dev/fuse -v $PWD:/mvdsv ${{ matrix.build-image }} bash -c -e 'export ARCH=$(dpkg --print-architecture);export DEBIAN_FRONTEND=noninteractive;mkdir -p /etc/apt/apt.conf.d;echo "APT::Install-Recommends "0"; APT::AutoRemove::RecommendsImportant "false";" >> /etc/apt/apt.conf.d/01lean && apt-get -qqy update && apt-get -qqy dist-upgrade && apt-get -qqy install cmake build-essential libcurl4-openssl-dev && ln -sf "$(which make)" /usr/bin/gmake && cd /mvdsv && ./build_cmake.sh ${{ matrix.target }} && chown -R '$(id -u ${USER})':'$(id -g ${USER})' /mvdsv/build/${{ matrix.target }}||exit 3'
-             else
-               ./build_cmake.sh ${{ matrix.target }}
-             fi
+          if ${{ matrix.os  == 'linux' }}; then
+            docker run --platform linux/${{ matrix.arch }} --net=host --rm --device /dev/fuse -v $PWD:/mvdsv -w /mvdsv ${{ matrix.build-image }} bash -c -e '
+              set -e
+              apt-get -qq update
+              apt-get -qq --no-install-recommends install cmake build-essential libcurl4-openssl-dev ninja-build
+              ./build_cmake.sh ${{ matrix.target }}
+              chown -R '$(id -u ${USER})':'$(id -g ${USER})' build/${{ matrix.target }} || exit 3
+            '
+          else
+            ./build_cmake.sh ${{ matrix.target }}
+          fi
       - name: Create checksum
         run: |
              md5sum build/${{ matrix.target }}/mvdsv${{ matrix.ext }} > build/${{ matrix.target }}/mvdsv.md5

--- a/.github/workflows/build-targets.yml
+++ b/.github/workflows/build-targets.yml
@@ -2,7 +2,6 @@ name: build targets
 on: [push,pull_request]
 jobs:
   build:
-    if: github.repository == 'QW-Group/mvdsv'
     runs-on: ${{ matrix.base-image }}
     strategy:
       fail-fast: false
@@ -17,19 +16,19 @@ jobs:
            ext: ""
          - target: linux-i686
            os: linux
-           arch: i686
+           arch: i386
            base-image: ubuntu-latest
            build-image: i386/debian:stable
            ext: ""
          - target: linux-armhf
            os: linux
-           arch: armhf
+           arch: arm/v7
            base-image: ubuntu-latest
            build-image: arm32v7/debian:stable
            ext: ""
          - target: linux-aarch64
            os: linux
-           arch: aarch64
+           arch: arm64
            base-image: ubuntu-latest
            build-image: arm64v8/debian:stable
            ext: ""
@@ -48,24 +47,26 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        if: matrix.os == 'linux'
+
       - name: Prepare Build Environemnt
         shell: bash
-        run: |
-             if ${{ matrix.os  == 'linux' }}; then
-               sudo apt-get update
-               sudo apt-get -y install qemu-system-arm qemu-user-static
-             else
-               sudo apt-get update
-               sudo apt-get -y install build-essential cmake gcc-i686-linux-gnu
-               sudo apt-get -y install gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gcc-aarch64-linux-gnu libc6-dev-arm64-cross
-               sudo apt-get -y install gcc-mingw-w64-x86-64 gcc-mingw-w64-i686
-             fi
+        run: sudo apt-get update -qq && sudo apt-get -qq --no-install-recommends install build-essential cmake gcc-mingw-w64-x86-64 gcc-mingw-w64-i686
+        if: matrix.os == 'windows'
+
       - name: Build
-        shell: bash
         run: |
              if ${{ matrix.os  == 'linux' }}; then
-               docker pull ${{ matrix.build-image }}
-               docker run --net=host --rm --device /dev/fuse -v $PWD:/mvdsv ${{ matrix.build-image }} bash -c -e 'export ARCH=$(dpkg --print-architecture);export DEBIAN_FRONTEND=noninteractive;mkdir -p /etc/apt/apt.conf.d;echo "APT::Install-Recommends "0"; APT::AutoRemove::RecommendsImportant "false";" >> /etc/apt/apt.conf.d/01lean && apt-get -qqy update && apt-get -qqy dist-upgrade && apt-get -qqy install cmake build-essential libcurl4-openssl-dev && ln -sf "$(which make)" /usr/bin/gmake && cd /mvdsv && ./build_cmake.sh ${{ matrix.target }} && chown -R '$(id -u ${USER})':'$(id -g ${USER})' /mvdsv/build/${{ matrix.target }}||exit 3'
+               docker run --platform linux/${{ matrix.arch }} --net=host --rm --device /dev/fuse -v $PWD:/mvdsv -w /mvdsv ${{ matrix.build-image }} bash -c -e '
+                 set -e
+                 apt-get -qq update
+                 apt-get -qq --no-install-recommends install cmake build-essential libcurl4-openssl-dev ninja-build
+                 ./build_cmake.sh ${{ matrix.target }}
+                 chown -R '$(id -u ${USER})':'$(id -g ${USER})' build/${{ matrix.target }} || exit 3
+               '
              else
                ./build_cmake.sh ${{ matrix.target }}
              fi


### PR DESCRIPTION
Also allows the `build-targets.yml` workflow to run in forks, like ktx and ezquake-source repositories work.