### PR TITLE
Randomize the location in svs.clients array for new clients

### DIFF
--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -1131,16 +1131,15 @@ qbool CheckReConnect( netadr_t adr, int qport )
 void CountPlayersSpecsVips(int *clients_ptr, int *spectators_ptr, int *vips_ptr, client_t **newcl_ptr)
 {
 	client_t *cl = NULL, *newcl = NULL;
-	int clients = 0, spectators = 0, vips = 0;
+	client_t *free_slots[MAX_CLIENTS];
+	int clients = 0, spectators = 0, vips = 0, free_slots_counter = 0;
 	int i;
 
 	for (i = 0, cl = svs.clients; i < MAX_CLIENTS; i++, cl++)
 	{
 		if (cl->state == cs_free)
 		{
-			if (!newcl)
-				newcl = cl; // grab first available slot
-
+			free_slots[free_slots_counter++] = cl;
 			continue;
 		}
 
@@ -1163,8 +1162,10 @@ void CountPlayersSpecsVips(int *clients_ptr, int *spectators_ptr, int *vips_ptr,
 		*spectators_ptr = spectators;
 	if (vips_ptr)
 		*vips_ptr = vips;
-	if (newcl_ptr)
-		*newcl_ptr = newcl;
+
+	// select a random free slot from svs.clients for the client
+	if (newcl_ptr && free_slots_counter > 0)
+		*newcl_ptr = free_slots[rand() % free_slots_counter];
 }
 
 //==============================================


### PR DESCRIPTION
Players are assigned the first available spot in the svs.clients array when they connect. On an empty server, this means that player1 is placed at svs.clients[0], player2 at svs.clients[1], and so on.

KTX iterates over svs.clients at the start of a match to decide where each player will spawn. This becomes problematic when there are fewer spawn points than players. A good example is dm3, which only has six spawns.

In the scenario where players connect to an empty server, they occupy the indexes 0 through 7 in the svs.clients array and are processed in this predictable order. This means player1 gets a random spawn before player2, player2 before player3, and so forth.

When it reaches player7, all spawn points are occupied. A random spawn is selected, and the player at that spawn point will be telefragged. Similarly, player8, the last to be processed, will also cause a telefrag.

By randomizing where new players are placed in the svs.clients array, we eliminate the possibility of predicting where in the array a player will be located, and thus also remove the possibility of manipulating the telefrag outcomes.