### PR TITLE
Add more serverinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ build/vs/*.exe
 build/vs/*.db
 build/vs/*.def
 build/vs/*.ilk
+build/
 /.cache

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -171,6 +171,9 @@ cvar_t	coop = {"coop", "0"}; // dont delete this variable - it used by mods
 cvar_t	sv_paused = {"sv_paused", "0", CVAR_ROM};
 
 cvar_t	hostname = {"hostname", "unnamed", CVAR_SERVERINFO};
+cvar_t	hostport = {"hostport", "", CVAR_SERVERINFO};
+cvar_t	countrycode = {"countrycode", "", CVAR_SERVERINFO};
+cvar_t	city = {"city", "", CVAR_SERVERINFO};
 
 cvar_t sv_forcenick = {"sv_forcenick", "0"}; //0 - don't force; 1 - as login;
 cvar_t sv_registrationinfo = {"sv_registrationinfo", ""}; // text shown before "enter login"
@@ -3431,6 +3434,9 @@ void SV_InitLocal (void)
 	Cvar_Register (&maxspectators);
 	Cvar_Register (&maxvip_spectators);
 	Cvar_Register (&hostname);
+	Cvar_Register (&hostport);
+	Cvar_Register (&countrycode);
+	Cvar_Register (&city);
 	Cvar_Register (&deathmatch);
 	Cvar_Register (&watervis);
 	Cvar_Register (&serverdemo);


### PR DESCRIPTION
Added three new serverinfo cvars:
- hostport
- countrycode
- city

Requested by Xantom:
```
mvdsv: currently hostname is used as a title, e.g. QUAKE.SE KTX:28501 and if there is an ongoing game QUAKE.SE KTX:28501 (red vs blue). This makes sense for the  in-game server browser.

But having to parse/guess info from that field is poo due to no common standard used. Another issue is trying to get proper geo info as ip lookup is pretty inaccurate.

Suggestions to config (optional)
• Add field *hostport (quake.se:28501)
• Add fields *cc (se), *city (Stockholm)
```