### PR TITLE
PROTOCOL: Align MVD/QTV with gameplay protocol.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,9 +128,11 @@ set(LFLAGS)
 
 
 ######################################################################################################
-
-# Set target
-add_executable(${PROJECT_NAME} ${SRC_COMMON})
+# Mark the executable as a non-console application
+if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+	set(TARGET_TYPE WIN32)
+endif()
+add_executable(${PROJECT_NAME} ${TARGET_TYPE} ${SRC_COMMON})
 set_target_properties(${PROJECT_NAME}
 	PROPERTIES #PREFIX "" # Strip lib prefix.
 	C_VISIBILITY_PRESET hidden # Hide all symbols unless excplicitly marked to export.
@@ -154,7 +156,9 @@ if(UNIX)
 else()
 	target_link_libraries(${PROJECT_NAME} ws2_32)
 	target_link_libraries(${PROJECT_NAME} winmm)
-	set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc")
+	if(NOT CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+		set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc")
+	endif()
 endif()
 
 
@@ -192,7 +196,9 @@ endif()
 # Assign compiler flags
 target_compile_options(${PROJECT_NAME} PRIVATE ${CFLAGS})
 
-target_link_libraries(${PROJECT_NAME} -lpthread)
+if(NOT CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+	target_link_libraries(${PROJECT_NAME} -lpthread)
+endif()
 
 
 ######################################################################################################

--- a/src/bothdefs.h
+++ b/src/bothdefs.h
@@ -48,10 +48,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //
 // per-level limits
 //
+#define	MAX_STATIC_ENTITIES     2048    // Could be MAX_MODELS - MAX_EDICTS, but static allocation
 #define	MAX_EDICTS              2048    // can't encode more than this, see SV_WriteDelta
 #define MAX_EDICTS_SAFE         512     // lower limit, to make sure no client limits exceeded
 #define	MAX_LIGHTSTYLES         64
-#define	MAX_MODELS              512     // can't encode more than this, see SV_WriteDelta
+#define	MAX_MODELS              4096    // really just UINT16_MAX, see SV_WriteDelta, PEXT_MODELDBL, dynamic + static entities
 #define	MAX_SOUNDS              256     // so they cannot be blindly increased
 #define MAX_VWEP_MODELS         32      // could be increased to 256
 

--- a/src/bspfile.h
+++ b/src/bspfile.h
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define	MAX_MAP_HULLS		4
 
-#define	MAX_MAP_MODELS		512
+#define	MAX_MAP_MODELS		4096
 #define	MAX_MAP_BRUSHES		4096
 #define	MAX_MAP_ENTITIES	1024
 #define	MAX_MAP_ENTSTRING	65536

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -342,7 +342,7 @@ void PF2_sprint(int entnum, int level, char *s, int flags)
 		flags = 0;
 	if (entnum < 1 || entnum > MAX_CLIENTS)
 	{
-		Con_Printf("tried to sprint to a non-client %d \n", entnum);
+		Con_Printf("tried to sprint to a non-client %d (%s)\n", entnum, s);
 		return;
 	}
 

--- a/src/server.h
+++ b/src/server.h
@@ -126,7 +126,7 @@ typedef struct
 
 	qbool		   mvdrecording;
 
-	entity_state_t static_entities[512];
+	entity_state_t static_entities[MAX_STATIC_ENTITIES];
 	int            static_entity_count;
 } server_t;
 

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1211,6 +1211,31 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 
 	MSG_WriteByte(&buf, svc_serverdata);
 
+#ifdef FTE_PEXT_256PACKETENTITIES
+	demo.recorder.fteprotocolextensions |= FTE_PEXT_256PACKETENTITIES;
+#endif
+#ifdef FTE_PEXT_MODELDBL
+	demo.recorder.fteprotocolextensions |= FTE_PEXT_MODELDBL;
+#endif
+#ifdef FTE_PEXT_ENTITYDBL
+	demo.recorder.fteprotocolextensions |= FTE_PEXT_ENTITYDBL;
+#endif
+#ifdef FTE_PEXT_ENTITYDBL2
+	demo.recorder.fteprotocolextensions |= FTE_PEXT_ENTITYDBL2;
+#endif
+#ifdef FTE_PEXT_SPAWNSTATIC2
+	demo.recorder.fteprotocolextensions |= FTE_PEXT_SPAWNSTATIC2;
+#endif
+#ifdef FTE_PEXT_TRANS
+	demo.recorder.fteprotocolextensions |= FTE_PEXT_TRANS;
+#endif
+#ifdef FTE_PEXT_COLOURMOD
+	demo.recorder.fteprotocolextensions |= FTE_PEXT_COLOURMOD;
+#endif
+#ifdef FTE_PEXT2_VOICECHAT
+	demo.recorder.fteprotocolextensions2 |= FTE_PEXT2_VOICECHAT;
+#endif
+
 #ifdef FTE_PEXT_FLOATCOORDS
 	//fix up extensions to match sv_bigcoords correctly. sorry for old clients not working.
 	if (msg_coordsize == 4)
@@ -1328,8 +1353,15 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 			MSG_WriteByte (&buf, n);
 			SV_WriteRecordMVDMessage (&buf);
 			SZ_Clear (&buf);
-			MSG_WriteByte (&buf, svc_modellist);
-			MSG_WriteByte (&buf, n + 1);
+			if (n + 1 > 0xff)
+			{
+				MSG_WriteByte (&buf, svc_fte_modellistshort);
+				MSG_WriteShort (&buf, n + 1);
+			} else
+			{
+				MSG_WriteByte (&buf, svc_modellist);
+				MSG_WriteByte (&buf, n + 1);
+			}
 		}
 		n++;
 		s = sv.model_precache[n+1];

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1321,8 +1321,9 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 	while (s)
 	{
 		MSG_WriteString (&buf, s);
-		if (buf.cursize > MAX_MSGLEN/2)
+		if (buf.cursize > MAX_MSGLEN/2 && n & 0xff)
 		{
+			// partial flush as long as not at a zero boundary
 			MSG_WriteByte (&buf, 0);
 			MSG_WriteByte (&buf, n);
 			SV_WriteRecordMVDMessage (&buf);

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -159,6 +159,9 @@ void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, s
 		bits |= U_MODEL;
 #ifdef FTE_PEXT_ENTITYDBL
 		if (to->modelindex > 255) {
+			if (to->modelindex >= 512) {
+				bits &= ~U_MODEL;
+			}
 			evenmorebits |= U_FTE_MODELDBL;
 			required_extensions |= FTE_PEXT_MODELDBL;
 		}
@@ -264,6 +267,8 @@ void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, s
 
 	if (bits & U_MODEL)
 		MSG_WriteByte(msg, to->modelindex & 255);
+	else if (evenmorebits & U_FTE_MODELDBL)
+		MSG_WriteShort(msg, to->modelindex);
 	if (bits & U_FRAME)
 		MSG_WriteByte(msg, to->frame);
 	if (bits & U_COLORMAP)


### PR DESCRIPTION
When merged, mvdsv must be paired with a new version of QTV or QTV-Go as previous versions didn't support these extensions.