### PR TITLE
Add coords to CVAR_SERVERINFO

### DIFF
--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -171,10 +171,11 @@ cvar_t	coop = {"coop", "0"}; // dont delete this variable - it used by mods
 
 cvar_t	sv_paused = {"sv_paused", "0", CVAR_ROM};
 
-cvar_t	hostname = {"hostname", "unnamed", CVAR_SERVERINFO};
-cvar_t	hostport = {"hostport", "", CVAR_SERVERINFO};
-cvar_t	countrycode = {"countrycode", "", CVAR_SERVERINFO};
-cvar_t	city = {"city", "", CVAR_SERVERINFO};
+cvar_t	hostname = {"hostname", "unnamed", CVAR_SERVERINFO}; // example: "QUAKE.SE KTX:28501"
+cvar_t	hostport = {"hostport", "", CVAR_SERVERINFO}; // example: "quake.se:28501"
+cvar_t	countrycode = {"countrycode", "", CVAR_SERVERINFO}; // example: "se"
+cvar_t	city = {"city", "", CVAR_SERVERINFO}; // example: "Stockholm"
+cvar_t	coords = {"coords", "", CVAR_SERVERINFO}; // example: "59.3327,18.0656"
 
 cvar_t sv_forcenick = {"sv_forcenick", "0"}; //0 - don't force; 1 - as login;
 cvar_t sv_registrationinfo = {"sv_registrationinfo", ""}; // text shown before "enter login"


### PR DESCRIPTION
This is a complement to the existing properties `countrycode` and `city`. The motivation is to make it easy to grab geo info as IP to geo lookup is inaccurate and cumbersome.

Suggested format `lat,long` (example: `59.3327,18.0656`). This adds another `23` chars to the serverinfo string (max length is `512`). 

Sample serverinfo from a server with an ongoing game + `coords` added (total length = `404`):
```
\maxfps\77\pm_ktjump\1\*version\MVDSV 1.20-dev\*z_ext\511\teamplay\2\maxspectators\12\sv_antilag\2\*admin\ERRH @ https://discord.quake.world\ktxver\1.46-dev\mode\2on2\*gamedir\qw\maxclients\4\timelimit\3\deathmatch\4\*qvm\so\*progs\so\map\povdmm4\serverdemo\2on2_swe_vs_red[povdmm4]20250222-1522.mvd\epoch\1740237763\hostname\de.quake.world:27501 [QW-Group]\fpd\142\status\Standby\coords\59.3327,18.0656
```