### PR TITLE
Support sending QTV events to regular clients

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -210,7 +210,8 @@ typedef enum
 	QUL_NONE = 0,	//
 	QUL_ADD,		// user joined
 	QUL_CHANGE,		// user changed something like name or something
-	QUL_DEL			// user dropped
+	QUL_DEL,		// user dropped
+	QUL_INIT		// user init
 
 } qtvuserlist_t;
 

--- a/src/server.h
+++ b/src/server.h
@@ -1042,6 +1042,7 @@ void DemoWriteQTV (sizebuf_t *msg);
 void QTVsv_FreeUserList(mvddest_t *d);
 void QTV_Streams_List (void);
 void QTV_Streams_UserList (void);
+void QTV_Client_UserList (client_t *client);
 const char* SV_MVDDemoName(void);
 
 //

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -1478,6 +1478,11 @@ static void SVC_DirectConnect (void)
 	MVD_PlayerReset(NUM_FOR_EDICT(newcl->edict) - 1);
 
 	newcl->sendinfo = true;
+
+	if ((s = Info_Get(&newcl->_userinfo_ctx_, "qul")) && *s == '1')
+	{
+		QTV_Client_UserList(newcl);
+	}
 }
 
 static int char2int (int c)

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -2434,6 +2434,7 @@ static void Cmd_SetInfo_f (void)
 void ProcessUserInfoChange (client_t* sv_client, const char* key, const char* old_value)
 {
 	int i;
+	char *s;
 
 	// process any changed values
 	SV_ExtractFromUserinfo (sv_client, !strcmp(key, "name"));
@@ -2463,6 +2464,11 @@ void ProcessUserInfoChange (client_t* sv_client, const char* key, const char* ol
 			MSG_WriteString (&sv.reliable_datagram, nuw);
 			break;
 		}
+	}
+
+	if (strcmp(key, "qul") == 0 && (s = Info_Get(&sv_client->_userinfo_ctx_, key)) && *s == '1')
+	{
+		QTV_Client_UserList(sv_client);
 	}
 }
 


### PR DESCRIPTION
If a client has a userinfo key named qul set to 1, the server will relay QTV user list events to that client.

This feature allows ezQuake to display QTV users on the scoreboard.