### PR TITLE
Add message broadcasting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SRC_COMMON
 	"${DIR_SRC}/pr_exec.c"
 	"${DIR_SRC}/sha1.c"
 	"${DIR_SRC}/sha3.c"
+	"${DIR_SRC}/sv_broadcast.c"
 	"${DIR_SRC}/sv_ccmds.c"
 	"${DIR_SRC}/sv_demo.c"
 	"${DIR_SRC}/sv_demo_misc.c"

--- a/src/common.c
+++ b/src/common.c
@@ -1894,3 +1894,27 @@ int Q_namecmp(const char* s1, const char* s2)
 
 	return 0;
 }
+
+qbool Mutex_TryLockWithTimeout(mutex_t *m, unsigned long timeout_ms)
+{
+	unsigned long elapsed = 0;
+	unsigned long sleep_interval = 1;
+
+	while (elapsed < timeout_ms)
+	{
+		if (Mutex_TryLock(m))
+		{
+			return true;
+		}
+
+		Sys_Sleep(sleep_interval);
+		elapsed += sleep_interval;
+
+		if (sleep_interval < 32)
+		{
+			sleep_interval *= 2;
+		}
+	}
+
+	return false;
+}

--- a/src/qwsvdef.h
+++ b/src/qwsvdef.h
@@ -81,6 +81,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "sv_world.h"
 #include "pmove.h"
 #include "log.h"
+#include "sv_broadcast.h"
 
 #include "version.h"
 

--- a/src/sv_broadcast.h
+++ b/src/sv_broadcast.h
@@ -1,0 +1,45 @@
+#ifndef __SV_BROADCAST_H__
+#define __SV_BROADCAST_H__
+
+#include "qwsvdef.h"
+
+// The message prefix used by clients to trigger a broadcast.
+#define BROADCAST_PREFIX ".qw "
+#define BROADCAST_PREFIX_LEN (sizeof(BROADCAST_PREFIX) - 1)
+
+// Prefix used in log messages related to broadcasts.
+#define BROADCAST_LOG_PREFIX "BROADCAST:"
+
+// When this comment was added, there were approximately 800 servers registered
+// with the most popular master servers, so 4096 should be sufficient for the
+// foreseeable future.
+#define BROADCAST_MAX_SERVERS 4096
+
+// Defines the number of milliseconds to wait before giving up on acquiring the
+// server list lock.
+#define BROADCAST_SERVER_LIST_LOCK_TIMEOUT 5000
+
+// Wait up to 5 seconds before giving up on the queried master server.
+#define BROADCAST_MASTER_TIMEOUT 5
+
+// Updates the server list every 10 minutes.
+#define BROADCAST_SERVER_LIST_UPDATE_INTERVAL 600.0
+
+// Permits broadcasts every 30 seconds.
+#define BROADCAST_MESSAGE_INTERVAL 30.0
+
+// Maximum number of retries for each message.
+#define BROADCAST_MAX_RETRIES 3
+
+// Limits the number of entries each IP address can occupy in the broadcast
+// server list. This is a safeguard against master server poisoning. Currently,
+// there is no server that uses more than 12 ports.
+#define BROADCAST_SERVER_MAX_ENTRIES_PER_IP 25
+
+qbool SV_Broadcast(char *message);
+void SVC_Broadcast(void);
+void SV_BroadcastInit(void);
+void SV_BroadcastUpdateServerList(qbool force_update);
+void SV_BroadcastUpdateServerList_f(void);
+
+#endif /* !__SV_BROADCAST_H__ */

--- a/src/sv_ccmds.c
+++ b/src/sv_ccmds.c
@@ -1865,6 +1865,7 @@ void SV_InitOperatorCommands (void)
 	}
 #endif
 	Cmd_AddCommand ("setmaster", SV_SetMaster_f);
+	Cmd_AddCommand ("updatebroadcasts", SV_BroadcastUpdateServerList_f);
 
 	Cmd_AddCommand ("heartbeat", SV_Heartbeat_f);
 	Cmd_AddCommand ("save", SV_SaveGame_f); 

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -142,6 +142,8 @@ cvar_t	sv_serverip = {"sv_serverip", ""};
 cvar_t	sv_forcespec_onfull = {"sv_forcespec_onfull", "2"};
 cvar_t	sv_maxdownloadrate = {"sv_maxdownloadrate", "0"};
 cvar_t	sv_idlesleep = {"sv_idlesleep", "0"};
+cvar_t	sv_broadcast_enabled = {"sv_broadcast_enabled", "0"};
+cvar_t	sv_broadcast_sender_validation_enabled = {"sv_broadcast_sender_validation_enabled", "1"};
 
 cvar_t  sv_loadentfiles = {"sv_loadentfiles", "1"}; //loads .ent files by default if there
 cvar_t  sv_loadentfiles_dir = {"sv_loadentfiles_dir", ""}; // check for .ent file in maps/sv_loadentfiles_dir first then just maps/
@@ -1947,6 +1949,8 @@ static void SV_ConnectionlessPacket (void)
 		SVC_DemoListRegex ();
 	else if (!strcmp(c,"qtvusers"))
 		SVC_QTVUsers ();
+	else if (!strcmp(c,"broadcast"))
+		SVC_Broadcast ();
 	else
 		Con_Printf ("bad connectionless packet from %s:\n%s\n"
 		            , NET_AdrToString (net_from), s);
@@ -3360,6 +3364,8 @@ void SV_Frame (double time1)
 
 	if ((int)sv_idlesleep.value > 0)
 		SV_IdleSleep();
+
+	SV_BroadcastUpdateServerList(false);
 }
 
 /*
@@ -3414,6 +3420,7 @@ void SV_InitLocal (void)
 
 	SV_InitOperatorCommands	();
 	SV_UserInit ();
+	SV_BroadcastInit ();
 
 	Cvar_Register (&sv_getrealip);
 	Cvar_Register (&sv_maxdownloadrate);
@@ -3424,6 +3431,9 @@ void SV_InitLocal (void)
 #ifdef SERVERONLY
 	Cvar_Register (&rcon_password);
 	Cvar_Register (&password);
+
+	Cvar_Register (&sv_broadcast_enabled);
+	Cvar_Register (&sv_broadcast_sender_validation_enabled);
 #endif
 
 	Cvar_Register (&sv_hashpasswords);

--- a/src/sv_master.c
+++ b/src/sv_master.c
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define HEARTBEAT_SECONDS 300
 
-static netadr_t master_adr[MAX_MASTERS]; // address of group servers
+netadr_t master_adr[MAX_MASTERS]; // address of group servers
 
 /*
 ====================

--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -586,8 +586,22 @@ int Sys_CreateThread(DWORD (WINAPI *func)(void *), void *param)
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
     pthread_attr_setschedpolicy(&attr, SCHED_OTHER);   // ale gowno
 
-    pthread_create(&thread, &attr, (void *)func, param);
-    return 1;
+    return pthread_create(&thread, &attr, (void *)func, param);
+}
+
+void Mutex_Init(mutex_t *m)
+{
+	pthread_mutex_init(&m->lock, NULL);
+}
+
+void Mutex_Unlock(mutex_t *m)
+{
+	pthread_mutex_unlock(&m->lock);
+}
+
+qbool Mutex_TryLock(mutex_t *m)
+{
+	return pthread_mutex_trylock(&m->lock) == 0;
 }
 
 // Function only_digits was copied from bind (DNS server) sources.

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -713,9 +713,27 @@ int Sys_CreateThread(DWORD (WINAPI *func)(void *), void *param)
         CREATE_SUSPENDED,   // creation flags
         &threadid);         // pointer to receive thread ID
 
+    if (thread == NULL)
+        return (int)GetLastError();
+
     ResumeThread(thread);
 
-    return 1;
+    return 0;
+}
+
+void Mutex_Init(mutex_t *m)
+{
+	InitializeCriticalSection(&m->lock);
+}
+
+void Mutex_Unlock(mutex_t *m)
+{
+	LeaveCriticalSection(&m->lock);
+}
+
+qbool Mutex_TryLock(mutex_t *m)
+{
+	return TryEnterCriticalSection(&m->lock) != 0;
 }
 
 #ifdef _CONSOLE

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -1807,6 +1807,14 @@ static void SV_Say (qbool team)
 		snprintf(text, sizeof(text), "%s\n", p);
 	}
 
+	if (!team && strncmp(text, BROADCAST_PREFIX, BROADCAST_PREFIX_LEN) == 0)
+	{
+		if (!SV_Broadcast(text+BROADCAST_PREFIX_LEN))
+		{
+			return;
+		}
+	}
+
 	if (!sv_client->logged && !sv_client->logged_in_via_web)
 	{
 		SV_ParseLogin(sv_client);

--- a/src/sys.h
+++ b/src/sys.h
@@ -149,4 +149,19 @@ void *Sys_DLProc (DL_t dl, const char *name);
 
 int  Sys_CreateThread(DWORD (WINAPI *func)(void *), void *param);
 
+
+typedef struct
+{
+#ifdef _WIN32
+	CRITICAL_SECTION lock;
+#else
+	pthread_mutex_t lock;
+#endif
+} mutex_t;
+
+void Mutex_Init(mutex_t *l);
+void Mutex_Unlock(mutex_t *l);
+qbool Mutex_TryLock(mutex_t *m);
+qbool Mutex_TryLockWithTimeout(mutex_t *m, unsigned long timeout_ms);
+
 #endif /* !__SYS_H__ */


### PR DESCRIPTION
By setting `sv_broadcast_enabled` to `1`, connected players can broadcast messages to other servers by typing:

`.qw <message>`

The server will emit the message to all servers retrieved from the configured master servers.

The payload that is sent is formatted as follows:
`\hostport\<hostport>\name\<name>\message\<message>`

When a server receives a message, the IP address and port of the sending server are prepended to the payload in the following format:
`\addr\<ip>:<port>`

If `\hostport` is set, that information is used in the message, otherwise, the sender's IP address and port are used as a fallback.

Example:
`[tot.qwsv.net:27500] ToT_Oddjob: prac please`

Messages are received using the new connectionless command broadcast, which serves as the endpoint for accepting messages from other servers.

By default, only servers discovered through master server queries are allowed to send messages. This validation can be disabled by setting `sv_broadcast_sender_validation_enabled` to `0`.

The server automatically queries the configured master servers every `10` minutes. You can manually trigger the query by executing the `updatebroadcasts` command in the console.

New command:

- `updatebroadcasts` Queries the master servers and updates the list of broadcast servers.

New cvars:

- `sv_broadcast_enabled` Enables or disables broadcasting to all connected clients.
- `sv_broadcast_sender_validation_enabled` Validates the sender's address before forwarding messages to clients.