### PR TITLE
Broadcast related fixes

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1895,14 +1895,14 @@ int Q_namecmp(const char* s1, const char* s2)
 	return 0;
 }
 
-qbool Mutex_TryLockWithTimeout(mutex_t *m, unsigned long timeout_ms)
+qbool Sys_MutexTryLockWithTimeout(mutex_t *m, unsigned long timeout_ms)
 {
 	unsigned long elapsed = 0;
 	unsigned long sleep_interval = 1;
 
 	while (elapsed < timeout_ms)
 	{
-		if (Mutex_TryLock(m))
+		if (Sys_MutexTryLock(m))
 		{
 			return true;
 		}

--- a/src/sv_broadcast.c
+++ b/src/sv_broadcast.c
@@ -1,3 +1,19 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
 #include "qwsvdef.h"
 
 typedef struct {

--- a/src/sv_broadcast.h
+++ b/src/sv_broadcast.h
@@ -44,8 +44,8 @@
 // Permits broadcasts every 30 seconds.
 #define BROADCAST_MESSAGE_INTERVAL 30.0
 
-// Maximum number of retries for each message.
-#define BROADCAST_MAX_RETRIES 3
+// Maximum number of errors for a broadcast before giving up.
+#define BROADCAST_MAX_ERRORS 5
 
 // Limits the number of entries each IP address can occupy in the broadcast
 // server list. This is a safeguard against master server poisoning. Currently,

--- a/src/sv_broadcast.h
+++ b/src/sv_broadcast.h
@@ -1,3 +1,19 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
 #ifndef __SV_BROADCAST_H__
 #define __SV_BROADCAST_H__
 

--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -589,17 +589,17 @@ int Sys_CreateThread(DWORD (WINAPI *func)(void *), void *param)
     return pthread_create(&thread, &attr, (void *)func, param);
 }
 
-void Mutex_Init(mutex_t *m)
+void Sys_MutexInit(mutex_t *m)
 {
 	pthread_mutex_init(&m->lock, NULL);
 }
 
-void Mutex_Unlock(mutex_t *m)
+void Sys_MutexUnlock(mutex_t *m)
 {
 	pthread_mutex_unlock(&m->lock);
 }
 
-qbool Mutex_TryLock(mutex_t *m)
+qbool Sys_MutexTryLock(mutex_t *m)
 {
 	return pthread_mutex_trylock(&m->lock) == 0;
 }

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -721,17 +721,17 @@ int Sys_CreateThread(DWORD (WINAPI *func)(void *), void *param)
     return 0;
 }
 
-void Mutex_Init(mutex_t *m)
+void Sys_MutexInit(mutex_t *m)
 {
 	InitializeCriticalSection(&m->lock);
 }
 
-void Mutex_Unlock(mutex_t *m)
+void Sys_MutexUnlock(mutex_t *m)
 {
 	LeaveCriticalSection(&m->lock);
 }
 
-qbool Mutex_TryLock(mutex_t *m)
+qbool Sys_MutexTryLock(mutex_t *m)
 {
 	return TryEnterCriticalSection(&m->lock) != 0;
 }

--- a/src/sys.h
+++ b/src/sys.h
@@ -159,9 +159,9 @@ typedef struct
 #endif
 } mutex_t;
 
-void Mutex_Init(mutex_t *l);
-void Mutex_Unlock(mutex_t *l);
-qbool Mutex_TryLock(mutex_t *m);
-qbool Mutex_TryLockWithTimeout(mutex_t *m, unsigned long timeout_ms);
+void Sys_MutexInit(mutex_t *l);
+void Sys_MutexUnlock(mutex_t *l);
+qbool Sys_MutexTryLock(mutex_t *m);
+qbool Sys_MutexTryLockWithTimeout(mutex_t *m, unsigned long timeout_ms);
 
 #endif /* !__SYS_H__ */


### PR DESCRIPTION
This PR addresses a few things that @jite pointed out:

1. Fixed the names of the mutex functions.
2. Added license headers to the new source files.

I also came up with a better way to emit broadcast messages that doesn't require using the main server socket. Instead, we now create a separate socket and include the actual server port in the broadcast payload.

As a result, we only need to validate the source address when determining whether a broadcast should be relayed.

This means that people who installed the version merged yesterday will not receive messages from servers using this fix, since the source port validation of the incoming message will fail.

I think this is acceptable, though, as no release has been made yet, and the previous PR was merged less than 24 hours ago.