### PR TITLE
Update broadcast message

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -857,12 +857,12 @@ key and returns the associated value, or an empty string.
 char *Info_ValueForKey (char *s, const char *key)
 {
 	char	pkey[512];
-	static	char value[4][512]; // use two buffers so compares
+	static	char value[INFO_VALUE_MAX_ENTRIES][512]; // use two buffers so compares
 	// work without stomping on each other
 	static	int valueindex;
 	char	*o;
 
-	valueindex = (valueindex + 1) % 4;
+	valueindex = (valueindex + 1) % INFO_VALUE_MAX_ENTRIES;
 	if (*s == '\\')
 		s++;
 	while (1)

--- a/src/common.h
+++ b/src/common.h
@@ -175,6 +175,9 @@ void			Info_PrintList(ctxinfo_t *ctx);
 
 //char *Info_KeyNameForKeyNum (char *s, int key);
 
+// Defines how many Info_ValueForKey entries can be stored simultaneously.
+#define INFO_VALUE_MAX_ENTRIES 8
+
 char *Info_ValueForKey (char *s, const char *key);
 void Info_RemoveKey (char *s, const char *key);
 void Info_RemovePrefixedKeys (char *start, char prefix);


### PR DESCRIPTION
This change adds the current number of players and the max clients value to the broadcast.

In the SVC broadcast function, we check whether this new data is available. If it is, a new format is used when relaying data to clients.

Old format:
`[tot.qwsv.net:27500] ToT_Oddjob: prac now`

New format:
`> tot.qwsv.net:27500 [6/8] ToT_Oddjob: prac now`

Special thanks to Xantom for coming up with the idea to include the player count, and to bps for helping reformat the output message
