### PR TITLE
Three minor bot related fixes

### DIFF
--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -2354,7 +2354,10 @@ void PF2_SetBotUserInfo(int entnum, char *key, char *value, int flags)
 		{
 			char *nuw = Info_Get( &cl->_userinfo_ctx_, key );
 
-			Info_Set( &cl->_userinfoshort_ctx_, key, nuw );
+			if ( flags & SETUSERINFO_STAR )
+				Info_SetStar( &cl->_userinfoshort_ctx_, key, nuw );
+			else
+				Info_Set( &cl->_userinfoshort_ctx_, key, nuw );
 
 			i = cl - svs.clients;
 			MSG_WriteByte( &sv.reliable_datagram, svc_setinfo );

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -461,6 +461,7 @@ int SV_CalcPing (client_t *cl)
 	register client_frame_t *frame;
 	int count, i;
 	float ping;
+	char *botskill = NULL;
 
 
 	//bliP: 999 ping for connecting players
@@ -472,7 +473,8 @@ int SV_CalcPing (client_t *cl)
 	count = 0;
 #ifdef USE_PR2
 	if (cl->isBot) {
-		return 10;
+		botskill = Info_Get(&cl->_userinfo_ctx_, "*skill");
+		return strlen(botskill) > 0 ? atoi(botskill) : 10;
 	}
 #endif
 	for (frame = cl->frames, i=0 ; i<UPDATE_BACKUP ; i++, frame++)

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -612,6 +612,7 @@ This message can be up to around 5k with worst case string lengths.
 #define STATUS_SHOWTEAMS                16
 #define STATUS_SHOWQTV                  32
 #define STATUS_SHOWFLAGS                64
+#define STATUS_SHOWCLIENTTYPE		128
 
 static void SVC_Status (void)
 {
@@ -672,6 +673,10 @@ static void SVC_Status (void)
 					else {
 						Con_Printf(" \"\"");
 					}
+				}
+
+				if (opt & STATUS_SHOWCLIENTTYPE) {
+					Con_Printf(" \"%c\"", cl->isBot ? 'b' : 'h');
 				}
 
 				Con_Printf("\n");

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -2289,6 +2289,7 @@ char *shortinfotbl[] =
 	"gender",
 	"*auth",
 	"*flag",
+	"*skill",
 	//"*client",
 	//"*spectator",
 	//"*VIP",


### PR DESCRIPTION
1. Fix userinfo star usage in `PF2_SetBotUserInfo` the function incorrectly assumed that the provided userinfo key wasn't a star key.

2. If the client is a bot and has the `*skill` userinfo key set, display that value as the ping. Otherwise, fall back to the default bot ping of 10.

3. Add a new bitfield, `STATUS_SHOWCLIENTTYPE`, that outputs an extra column in the SVC_Status output: `h` for humans and `b` for bots. This could potentially be extended in the future to support other client types, such as service clients.
