### PR TITLE
SV: preserve reliable messages across spawn chunks

### DIFF
--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -852,8 +852,6 @@ static void Cmd_Spawn_f (void)
 	}
 
 	// send all current names, colors, and frag counts
-	// FIXME: is this a good thing?
-	SZ_Clear (&sv_client->netchan.message);
 
 	// send current status of all other players
 

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -861,9 +861,10 @@ static void Cmd_Spawn_f (void)
 
 	if (i < MAX_CLIENTS)
 	{
-		MSG_WriteByte (&sv_client->netchan.message, svc_stufftext);
-		MSG_WriteString (&sv_client->netchan.message,
-		                 va("cmd spawn %i %d\n", svs.spawncount, i) );
+		char *cmd = va("cmd spawn %i %d\n", svs.spawncount, i);
+
+		ClientReliableWrite_Begin (sv_client, svc_stufftext, 2 + strlen(cmd));
+		ClientReliableWrite_String (sv_client, cmd);
 		return;
 	}
 


### PR DESCRIPTION
## Summary

`Cmd_Spawn_f()` clears `netchan.message` whenever it continues the client
table. A reliable update queued between chunks can then be discarded after
its client slot has already been sent.

Remove the clear and send the `cmd spawn` continuation through the per-client
reliable writer. This preserves queued updates, lets the continuation use
the backbuffer when the front buffer is full, and keeps it ordered after
pending reliable data.

Fixes #226.

## Testing

- CMake `RelWithDebInfo` build passed with both changes.
- Focused C test using the production buffer and reliable-writer code:
  reproduced the original continuation overflow with 1,440 queued bytes;
  verified that the reliable writer preserves those bytes and queues the
  complete continuation in the backbuffer; verified ordering behind pending
  backbuffer data and the ordinary front-buffer case.
- Earlier validation of the clear removal: deterministic Python reproduction
  delivered the queued `svc_setinfo` and left the observer with the
  authoritative team; a backbuffer stress test with the userinfo spam guard
  disabled delivered 768/768 ordered updates and the observer spawned with
  the final value. These end-to-end tests were not rerun for the continuation
  change.
