### PR TITLE
CSQC support PR2 only(based on fte)

### DIFF
--- a/src/bothdefs.h
+++ b/src/bothdefs.h
@@ -61,7 +61,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //
 // stats are integers communicated to the client by the server
 //
-#define	MAX_CL_STATS			32
+#define	MAX_CL_STATS			128		// 0..31 engine-fixed, 32..127 CSQC (clientstat/pointerstat)
 #define	STAT_HEALTH				0
 //#define	STAT_FRAGS				1
 #define	STAT_WEAPON				2

--- a/src/bothdefs.h
+++ b/src/bothdefs.h
@@ -62,6 +62,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // stats are integers communicated to the client by the server
 //
 #define	MAX_CL_STATS			128		// 0..31 engine-fixed, 32..127 CSQC (clientstat/pointerstat)
+#define	MAX_WIRE_STATS			32		// legacy stats stock clients understand (MVD/QTV default)
 #define	STAT_HEALTH				0
 //#define	STAT_FRAGS				1
 #define	STAT_WEAPON				2

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -697,6 +697,24 @@ void Cmd_TokenizeString (const char *text)
 	Cmd_TokenizeStringEx(&cmd_tokenizecontext, text);
 }
 
+/*
+=============
+Cmd_SetRawArgv0
+
+Sets the command-line token state to a single raw argument (argc=1,
+argv[0] = whole text) WITHOUT tokenizing, so Cmd_Argv(0) returns the full
+string even when it contains whitespace. Used to expose the CSQC sendevent
+event name to the game via trap_Argv(0).
+=============
+*/
+void Cmd_SetRawArgv0 (const char *text)
+{
+	memset(&cmd_tokenizecontext, 0, sizeof(cmd_tokenizecontext));
+	strlcpy(cmd_tokenizecontext.argv_buf, text, sizeof(cmd_tokenizecontext.argv_buf));
+	cmd_tokenizecontext.cmd_argc = 1;
+	cmd_tokenizecontext.cmd_argv[0] = cmd_tokenizecontext.argv_buf;
+}
+
 
 /*
 ============

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -148,6 +148,12 @@ void Cmd_TokenizeString (const char *text);
 // Takes a null terminated string.  Does not need to be /n terminated.
 // breaks the string up into arg tokens.
 
+void Cmd_SetRawArgv0 (const char *text);
+// Sets the command-line token state to a single raw argument (argc=1,
+// argv[0] = whole text) WITHOUT tokenizing, so Cmd_Argv(0) returns the
+// full string even when it contains whitespace. Used to expose the CSQC
+// sendevent event name to the game via trap_Argv(0).
+
 void Cmd_ExecuteString (const char *text);
 // Parses a single line of text into arguments and tries to execute it
 // as if it was typed at the console

--- a/src/common.c
+++ b/src/common.c
@@ -366,6 +366,16 @@ float MSG_ReadFloat (void)
 		int l;
 	} dat;
 
+	// PR228 rev [12]: MSG_ReadFloat was the only reader without a cursize
+	// bound - a truncated message read past net_message (up to 11 bytes into
+	// .bss at max packet size). Set msg_badread and return like the other
+	// readers (FTE does the same).
+	if (msg_readcount + 4 > net_message.cursize)
+	{
+		msg_badread = true;
+		return -1;
+	}
+
 	dat.b[0] =	net_message.data[msg_readcount];
 	dat.b[1] =	net_message.data[msg_readcount+1];
 	dat.b[2] =	net_message.data[msg_readcount+2];

--- a/src/common.c
+++ b/src/common.c
@@ -366,7 +366,7 @@ float MSG_ReadFloat (void)
 		int l;
 	} dat;
 
-	// PR228 rev [12]: MSG_ReadFloat was the only reader without a cursize
+	// MSG_ReadFloat was the only reader without a cursize
 	// bound - a truncated message read past net_message (up to 11 bytes into
 	// .bss at max packet size). Set msg_badread and return like the other
 	// readers (FTE does the same).

--- a/src/g_public.h
+++ b/src/g_public.h
@@ -226,9 +226,9 @@ typedef enum
 	GAME_PAUSED_TIC,			// ( int duration_msec );	// duration is in msecs
 	GAME_CLEAR_EDICT,           // (self)
 #ifdef FTE_PEXT_CSQC
-	GAME_EDICT_CSQCSEND = 200,	// (self,other,int sendflags_lo,int sendflags_hi) — 64-битная
-								//   маска sendflags как два int (62 usable бита; fteqw передаёт
-								//   только младшее слово, hi=0)
+	GAME_EDICT_CSQCSEND = 200,	// (self,other,int sendflags_lo,int sendflags_hi) — 64-bit
+								//   sendflags mask as two ints (62 usable bits; fteqw passes
+								//   only the low word, hi=0)
 	GAME_QCREQUEST,				// CSQC sendevent: (self=client, arg0=argcount). The game pulls
 								//   the event name via trap_argv(0) (single raw arg, not tokenized)
 								//   and typed arg values via the qcrequestarg extension trap.

--- a/src/g_public.h
+++ b/src/g_public.h
@@ -227,7 +227,9 @@ typedef enum
 	GAME_CLEAR_EDICT,           // (self)
 #ifdef FTE_PEXT_CSQC
 	GAME_EDICT_CSQCSEND = 200,	// (self,other,int sendflags)
-	GAME_QCREQUEST,				// CSQC sendevent: (self=client, eventname, argcount, argtypes)
+	GAME_QCREQUEST,				// CSQC sendevent: (self=client, arg0=argcount). The game pulls
+								//   the event name via trap_argv(0) (single raw arg, not tokenized)
+								//   and typed arg values via the qcrequestarg extension trap.
 #endif
 } gameExport_t;
 

--- a/src/g_public.h
+++ b/src/g_public.h
@@ -226,7 +226,9 @@ typedef enum
 	GAME_PAUSED_TIC,			// ( int duration_msec );	// duration is in msecs
 	GAME_CLEAR_EDICT,           // (self)
 #ifdef FTE_PEXT_CSQC
-	GAME_EDICT_CSQCSEND = 200,	// (self,other,int sendflags)
+	GAME_EDICT_CSQCSEND = 200,	// (self,other,int sendflags_lo,int sendflags_hi) — 64-битная
+								//   маска sendflags как два int (62 usable бита; fteqw передаёт
+								//   только младшее слово, hi=0)
 	GAME_QCREQUEST,				// CSQC sendevent: (self=client, arg0=argcount). The game pulls
 								//   the event name via trap_argv(0) (single raw arg, not tokenized)
 								//   and typed arg values via the qcrequestarg extension trap.

--- a/src/g_public.h
+++ b/src/g_public.h
@@ -30,9 +30,13 @@
 //
 // g_public.h -- game module information visible to server
 
-#define	GAME_API_VERSION	16
+#define	GAME_API_VERSION	17
 
 /*
+ * Changes in GAME_API_VERSION 17:
+ * - GAME_EDICT_CSQCSEND (200) and GAME_QCREQUEST exports for CSQC
+ * - clientstat/pointerstat/setsendneeded extensions via G_Map_Extension
+ *
  * Changes in GAME_API_VERSION 16:
  * - server edict data removed from game edict: typedef struct shared_edict_s { entvars_t v;} edict_t;
  * - SetSting works for PR1 only
@@ -223,6 +227,7 @@ typedef enum
 	GAME_CLEAR_EDICT,           // (self)
 #ifdef FTE_PEXT_CSQC
 	GAME_EDICT_CSQCSEND = 200,	// (self,other,int sendflags)
+	GAME_QCREQUEST,				// CSQC sendevent: (self=client, eventname, argcount, argtypes)
 #endif
 } gameExport_t;
 

--- a/src/pr2.h
+++ b/src/pr2.h
@@ -91,7 +91,7 @@ void        PR2_ClearEdict(edict_t* e);
 #define PR_ClearEdict PR2_ClearEdict
 
 #ifdef FTE_PEXT_CSQC
-qbool       PR2_SendEntity(edict_t* e, edict_t* to, int sendflags);
+qbool       PR2_SendEntity(edict_t* e, edict_t* to, uint64_t sendflags);
 void        PR2_QCRequest(edict_t* cl_ent, int argcount);
 #endif
 

--- a/src/pr2.h
+++ b/src/pr2.h
@@ -92,6 +92,7 @@ void        PR2_ClearEdict(edict_t* e);
 
 #ifdef FTE_PEXT_CSQC
 qbool       PR2_SendEntity(edict_t* e, edict_t* to, int sendflags);
+void        PR2_QCRequest(edict_t* cl_ent, const char* eventname, int argcount, int argtypes);
 #endif
 
 #endif /* !__PR2_H__ */

--- a/src/pr2.h
+++ b/src/pr2.h
@@ -92,7 +92,7 @@ void        PR2_ClearEdict(edict_t* e);
 
 #ifdef FTE_PEXT_CSQC
 qbool       PR2_SendEntity(edict_t* e, edict_t* to, int sendflags);
-void        PR2_QCRequest(edict_t* cl_ent, const char* eventname, int argcount, int argtypes);
+void        PR2_QCRequest(edict_t* cl_ent, const char* eventname, int argcount, int argtypes, unsigned int vm_str_off);
 #endif
 
 #endif /* !__PR2_H__ */

--- a/src/pr2.h
+++ b/src/pr2.h
@@ -92,7 +92,7 @@ void        PR2_ClearEdict(edict_t* e);
 
 #ifdef FTE_PEXT_CSQC
 qbool       PR2_SendEntity(edict_t* e, edict_t* to, int sendflags);
-void        PR2_QCRequest(edict_t* cl_ent, const char* eventname, int argcount, int argtypes, unsigned int vm_str_off);
+void        PR2_QCRequest(edict_t* cl_ent, int argcount);
 #endif
 
 #endif /* !__PR2_H__ */

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1231,7 +1231,7 @@ sizebuf_t *WriteDest2(int dest)
 
 	case MSG_CSQC:
 		// Only valid inside a GAME_EDICT_CSQCSEND call; the buffer is
-		// armed by SV_SendClientDatagram / SV_SendDemoMessage.
+		// armed per-client inside SV_EmitCSQCUpdate (sv_ents.c).
 		if (!csqcmsgbuffer.maxsize || !csqcmsgbuffer.data)
 			PR2_RunError("PF_Write_*: MSG_CSQC outside of SendEntity method");
 		return &csqcmsgbuffer;

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -65,6 +65,7 @@ static intptr_t EXT_SetSendNeeded(intptr_t *args);
 static intptr_t EXT_clientstat(intptr_t *args);
 static intptr_t EXT_pointerstat(intptr_t *args);
 static intptr_t EXT_globalstat(intptr_t *args);
+static intptr_t EXT_QCRequestArg(intptr_t *args);
 #endif
 static intptr_t EXT_MapExtFieldPtr(intptr_t *args);
 static intptr_t EXT_SetExtFieldPtr(intptr_t *args);
@@ -83,6 +84,7 @@ struct
 	{"clientstat",			EXT_clientstat},
 	{"pointerstat",			EXT_pointerstat},
 	{"globalstat",			EXT_globalstat},
+	{"qcrequestarg",		EXT_QCRequestArg},
 #endif
 };
 ext_syscall_t ext_syscall_tbl[256];
@@ -2058,6 +2060,17 @@ intptr_t EXT_globalstat(intptr_t *args)
 {
 	SV_QCStatGlobal (args[2], VMA(3), args[1]);
 	return 0;
+}
+
+// trap_qcrequestarg(idx, buf, size): copies argument idx of the qcrequest
+// currently being dispatched into the mod's buf and returns its type
+// (QCREQ_T_*, or -1 on out-of-range idx). Only meaningful inside the
+// GAME_QCREQUEST callback.
+intptr_t EXT_QCRequestArg(intptr_t *args)
+{
+	if (args[3] > 0)
+		VM_CheckBounds(sv_vm, args[2], args[3]);
+	return SV_QCRequestArg(args[1], VMA(2), args[3]);
 }
 #endif
 

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -2043,10 +2043,10 @@ intptr_t EXT_SetSendNeeded(intptr_t *args)
 }
 
 // trap_SetSendNeeded64(subject, flagslo, flagshi, to)
-//   64-битный вариант setsendneeded: маска мода (62 usable бита: lo = 0..31,
-//   hi = 32..61) передаётся двумя int, т.к. границы VM (native и QVM)
-//   32-битны. PRESENT/REMOVED (биты 0..1 pending-слова) движковые — маска
-//   режется до 62 бит ДО сдвига, чтобы не задеть их.
+ //   64-bit setsendneeded variant: the mod's mask (62 usable bits: lo = 0..31,
+ //   hi = 32..61) is passed as two ints, since VM word sizes (native and QVM)
+ //   are 32-bit. PRESENT/REMOVED (bits 0..1 of the pending word) are engine-side,
+ //   so the mask is trimmed to 62 bits BEFORE the shift to avoid touching them.
 intptr_t EXT_SetSendNeeded64(intptr_t *args)
 {
 	unsigned int subject = (unsigned int)args[1];

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1188,9 +1188,7 @@ MESSAGE WRITING
 #define	MSG_ALL			2		// reliable to all
 #define	MSG_INIT		3		// write to the init string
 #define	MSG_MULTICAST	4		// for multicast()
-#ifdef FTE_PEXT_CSQC
-#define	MSG_CSQC		5		// for csqc
-#endif
+// MSG_CSQC (5) is defined once in server.h, not duplicated here (F11)
 
 
 sizebuf_t *WriteDest2(int dest)

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -39,6 +39,9 @@
 const char *pr2_ent_data_ptr;
 vm_t *sv_vm = NULL;
 extern gameData_t gamedata;
+#ifdef FTE_PEXT_CSQC
+extern sizebuf_t csqcmsgbuffer;
+#endif
 
 static int PASSFLOAT(float f)
 {
@@ -59,6 +62,9 @@ static float GETFLOAT(int i)
 typedef intptr_t (*ext_syscall_t)(intptr_t *arg);
 #ifdef FTE_PEXT_CSQC
 static intptr_t EXT_SetSendNeeded(intptr_t *args);
+static intptr_t EXT_clientstat(intptr_t *args);
+static intptr_t EXT_pointerstat(intptr_t *args);
+static intptr_t EXT_globalstat(intptr_t *args);
 #endif
 static intptr_t EXT_MapExtFieldPtr(intptr_t *args);
 static intptr_t EXT_SetExtFieldPtr(intptr_t *args);
@@ -74,6 +80,9 @@ struct
 	{"GetExtFieldPtr",	EXT_GetExtFieldPtr},
 #ifdef FTE_PEXT_CSQC
 	{"setsendneeded",		EXT_SetSendNeeded},
+	{"clientstat",			EXT_clientstat},
+	{"pointerstat",			EXT_pointerstat},
+	{"globalstat",			EXT_globalstat},
 #endif
 };
 ext_syscall_t ext_syscall_tbl[256];
@@ -1219,9 +1228,11 @@ sizebuf_t *WriteDest2(int dest)
 		return &sv.multicast;
 
 	case MSG_CSQC:
-		// Should return a reference to the CSQC message buffer managed in sv_ents.c
-		PR2_RunError("PF_Write_*: MSG_CSQC not implemented yet.");
-		return NULL;
+		// Only valid inside a GAME_EDICT_CSQCSEND call; the buffer is
+		// armed by SV_SendClientDatagram / SV_SendDemoMessage.
+		if (!csqcmsgbuffer.maxsize || !csqcmsgbuffer.data)
+			PR2_RunError("PF_Write_*: MSG_CSQC outside of SendEntity method");
+		return &csqcmsgbuffer;
 
 	default:
 		PR2_RunError ("WriteDest: bad destination");
@@ -2003,7 +2014,51 @@ intptr_t PF2_FS_GetFileList(char *path, char *ext,
 #ifdef FTE_PEXT_CSQC
 intptr_t EXT_SetSendNeeded(intptr_t *args)
 {
-	PR2_RunError("SetSendNeeded not implemented yet.");
+	// trap_SetSendNeeded(subject, flags, to)
+	//   subject - entity number to flag
+	//   flags   - changed-field bits (shifted by SENDFLAGS_SHIFT on resend)
+	//   to      - 0 = broadcast, 1..N = specific client
+	unsigned int subject = (unsigned int)args[1];
+	uint64_t fl = (uint64_t)args[2] << SENDFLAGS_SHIFT;
+	unsigned int to = (unsigned int)args[3];
+
+	if (!to)
+	{	// broadcast
+		unsigned int i;
+		for (i = 0; i < MAX_CLIENTS; i++)
+			if (svs.clients[i].pendingcsqcbits && subject < (unsigned int)svs.clients[i].max_net_ents)
+				svs.clients[i].pendingcsqcbits[subject] |= fl;
+	}
+	else
+	{
+		to--;
+		if (to >= MAX_CLIENTS || !svs.clients[to].pendingcsqcbits || subject >= (unsigned int)svs.clients[to].max_net_ents)
+			return 0;	// some kind of error.
+		else
+			svs.clients[to].pendingcsqcbits[subject] |= fl;
+	}
+	return 0;
+}
+
+// trap_clientstat(statnum, type, fieldoffset)
+intptr_t EXT_clientstat(intptr_t *args)
+{
+	SV_QCStatFieldIdx (args[2], args[3], args[1]);
+	return 0;
+}
+
+// trap_pointerstat(statnum, type, ptr)
+intptr_t EXT_pointerstat(intptr_t *args)
+{
+	void *ptr = VM_ArgPtr(args[3]);
+	SV_QCStatPtr (args[2], ptr, args[1]);
+	return 0;
+}
+
+// trap_globalstat(statnum, type, name)
+intptr_t EXT_globalstat(intptr_t *args)
+{
+	SV_QCStatGlobal (args[2], VMA(3), args[1]);
 	return 0;
 }
 #endif

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -2146,6 +2146,10 @@ static intptr_t EXT_MapExtFieldPtr(intptr_t *args)
 		{
 			return offsetof(ext_entvars_t, colourmod) | GetExtFieldCookie();
 		}
+		if (!strcmp(key, "sendflags"))
+		{
+			return offsetof(ext_entvars_t, sendflags) | GetExtFieldCookie();
+		}
 		if (!strcmp(key, "SendEntity"))
 		{
 			return offsetof(ext_entvars_t, sendentity) | GetExtFieldCookie();

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -62,6 +62,7 @@ static float GETFLOAT(int i)
 typedef intptr_t (*ext_syscall_t)(intptr_t *arg);
 #ifdef FTE_PEXT_CSQC
 static intptr_t EXT_SetSendNeeded(intptr_t *args);
+static intptr_t EXT_SetSendNeeded64(intptr_t *args);
 static intptr_t EXT_clientstat(intptr_t *args);
 static intptr_t EXT_pointerstat(intptr_t *args);
 static intptr_t EXT_globalstat(intptr_t *args);
@@ -81,6 +82,7 @@ struct
 	{"GetExtFieldPtr",	EXT_GetExtFieldPtr},
 #ifdef FTE_PEXT_CSQC
 	{"setsendneeded",		EXT_SetSendNeeded},
+	{"setsendneeded64",		EXT_SetSendNeeded64},
 	{"clientstat",			EXT_clientstat},
 	{"pointerstat",			EXT_pointerstat},
 	{"globalstat",			EXT_globalstat},
@@ -2021,6 +2023,38 @@ intptr_t EXT_SetSendNeeded(intptr_t *args)
 	unsigned int subject = (unsigned int)args[1];
 	uint64_t fl = (uint64_t)args[2] << SENDFLAGS_SHIFT;
 	unsigned int to = (unsigned int)args[3];
+
+	if (!to)
+	{	// broadcast
+		unsigned int i;
+		for (i = 0; i < MAX_CLIENTS; i++)
+			if (svs.clients[i].pendingcsqcbits && subject < (unsigned int)svs.clients[i].max_net_ents)
+				svs.clients[i].pendingcsqcbits[subject] |= fl;
+	}
+	else
+	{
+		to--;
+		if (to >= MAX_CLIENTS || !svs.clients[to].pendingcsqcbits || subject >= (unsigned int)svs.clients[to].max_net_ents)
+			return 0;	// some kind of error.
+		else
+			svs.clients[to].pendingcsqcbits[subject] |= fl;
+	}
+	return 0;
+}
+
+// trap_SetSendNeeded64(subject, flagslo, flagshi, to)
+//   64-битный вариант setsendneeded: маска мода (62 usable бита: lo = 0..31,
+//   hi = 32..61) передаётся двумя int, т.к. границы VM (native и QVM)
+//   32-битны. PRESENT/REMOVED (биты 0..1 pending-слова) движковые — маска
+//   режется до 62 бит ДО сдвига, чтобы не задеть их.
+intptr_t EXT_SetSendNeeded64(intptr_t *args)
+{
+	unsigned int subject = (unsigned int)args[1];
+	uint64_t fl = ((uint64_t)(uint32_t)args[2]) | ((uint64_t)(uint32_t)args[3] << 32);
+	unsigned int to = (unsigned int)args[4];
+
+	fl &= (SENDFLAGS_USABLE >> SENDFLAGS_SHIFT);
+	fl <<= SENDFLAGS_SHIFT;
 
 	if (!to)
 	{	// broadcast

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1192,7 +1192,7 @@ MESSAGE WRITING
 #define	MSG_ALL			2		// reliable to all
 #define	MSG_INIT		3		// write to the init string
 #define	MSG_MULTICAST	4		// for multicast()
-// MSG_CSQC (5) is defined once in server.h, not duplicated here (F11)
+// MSG_CSQC (5) is defined once in server.h, not duplicated here.
 
 
 sizebuf_t *WriteDest2(int dest)
@@ -2114,8 +2114,10 @@ intptr_t EXT_globalstat(intptr_t *args)
 // GAME_QCREQUEST callback.
 intptr_t EXT_QCRequestArg(intptr_t *args)
 {
-	if (args[3] > 0)
-		VM_CheckBounds(sv_vm, args[2], args[3]);
+	// trap_qcrequestarg(idx, buf, size)
+	if (args[3] <= 0)
+		return -1;	// negative size would skip VM_CheckBounds and turn into a huge dstsize
+	VM_CheckBounds(sv_vm, args[2], args[3]);
 	return SV_QCRequestArg(args[1], VMA(2), args[3]);
 }
 #endif

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1256,8 +1256,44 @@ static client_t *Write_GetClient(void)
 	return &svs.clients[entnum - 1];
 }
 
+#ifdef FTE_PEXT_CSQC
+/*
+====================
+PF2_WriteCheckCSQC
+
+Classify the first byte written into a fresh multicast buffer: svc 83 starts a
+CSQC packet (PF2_multicast then routes it through SV_CSQCMulticast so only CSQC
+clients receive it), any other value a normal one. Only the first byte is
+inspected, so a payload byte equal to 0x53 is never mistaken for the svc.
+
+Writing svc 83 to a broadcast destination is a mod contract violation: it would
+bypass the CSQC client filter. MSG_ONE/MSG_INIT are accumulating streams whose
+message boundary cannot be recovered, so they cannot be checked here (the mod
+contract forbids CSQC packets there; see g_csqc.h in the mod).
+====================
+*/
+static void PF2_WriteCheckCSQC (int to, int data)
+{
+	if (to == MSG_MULTICAST)
+	{
+		if (sv.multicast.cursize == 0 && data == svc_fte_cgamepacket)
+			sv.multicast_csqc = true;
+	}
+	else if ((to == MSG_BROADCAST || to == MSG_ALL) && data == svc_fte_cgamepacket)
+	{
+		sizebuf_t *d = WriteDest2(to);
+
+		if (d && d->cursize == 0)
+			PR2_RunError("CSQC packets must be sent with multicast()");
+	}
+}
+#endif
+
 void PF2_WriteByte(int to, int data)
 {
+#ifdef FTE_PEXT_CSQC
+	PF2_WriteCheckCSQC(to, data);
+#endif
 	if (to == MSG_ONE)
 	{
 		client_t *cl = Write_GetClient();
@@ -1277,6 +1313,9 @@ void PF2_WriteByte(int to, int data)
 
 void PF2_WriteChar(int to, int data)
 {
+#ifdef FTE_PEXT_CSQC
+	PF2_WriteCheckCSQC(to, data);
+#endif
 	if (to == MSG_ONE)
 	{
 		client_t *cl = Write_GetClient();
@@ -1699,7 +1738,15 @@ void PF2_multicast(float x, float y, float z, int to)
 	o[0] = x;
 	o[1] = y;
 	o[2] = z;
-	SV_Multicast(o, to);
+#ifdef FTE_PEXT_CSQC
+	// A CSQC packet (first byte svc_fte_cgamepacket) goes to CSQC clients only.
+	// MULTICAST_MVD_HIDDEN is a raw hidden block, not a CSQC packet, so it is
+	// never routed here even if its first byte happens to be 0x53.
+	if (sv.multicast_csqc && to != MULTICAST_MVD_HIDDEN)
+		SV_CSQCMulticast (o, to);
+	else
+#endif
+		SV_Multicast (o, to);
 }
 
 /*

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1396,7 +1396,23 @@ void PF2_WriteString(int to, char *data)
 		}
 	}
 	else
-		MSG_WriteString(WriteDest2(to), data);
+	{
+		sizebuf_t *dest = WriteDest2(to);
+		int len = (data && *data) ? (int)strlen(data) + 1 : 1;
+
+		// PR228-rev [14]: SZ_GetSpace Sys_Errors when a *single* write exceeds
+		// maxsize even with allowoverflow (csqcmsgbuffer is only MAX_DATAGRAM).
+		// Such a payload can never fit the client datagram anyway, so for
+		// allowoverflow destinations mark it overflowed and drop it instead of
+		// killing the server. Non-overflow destinations keep the old Sys_Error.
+		if (dest->allowoverflow && len > dest->maxsize)
+		{
+			SZ_Clear(dest);
+			dest->overflowed = true;
+			return;
+		}
+		MSG_WriteString(dest, data);
+	}
 }
 
 void PF2_WriteEntity(int to, int data)
@@ -2014,16 +2030,11 @@ intptr_t PF2_FS_GetFileList(char *path, char *ext,
 }
 
 #ifdef FTE_PEXT_CSQC
-intptr_t EXT_SetSendNeeded(intptr_t *args)
+// Shared broadcast/unicast body of both setsendneeded traps. The mask is
+// already shifted to its final position in the pending word (PRESENT/REMOVED
+// in bits 0..1 are engine-side and must not be touched by mods).
+static void EXT_SetSendNeeded_Apply(unsigned int subject, uint64_t fl, unsigned int to)
 {
-	// trap_SetSendNeeded(subject, flags, to)
-	//   subject - entity number to flag
-	//   flags   - changed-field bits (shifted by SENDFLAGS_SHIFT on resend)
-	//   to      - 0 = broadcast, 1..N = specific client
-	unsigned int subject = (unsigned int)args[1];
-	uint64_t fl = (uint64_t)args[2] << SENDFLAGS_SHIFT;
-	unsigned int to = (unsigned int)args[3];
-
 	if (!to)
 	{	// broadcast
 		unsigned int i;
@@ -2035,10 +2046,25 @@ intptr_t EXT_SetSendNeeded(intptr_t *args)
 	{
 		to--;
 		if (to >= MAX_CLIENTS || !svs.clients[to].pendingcsqcbits || subject >= (unsigned int)svs.clients[to].max_net_ents)
-			return 0;	// some kind of error.
-		else
-			svs.clients[to].pendingcsqcbits[subject] |= fl;
+			return;	// some kind of error.
+		svs.clients[to].pendingcsqcbits[subject] |= fl;
 	}
+}
+
+intptr_t EXT_SetSendNeeded(intptr_t *args)
+{
+	// trap_SetSendNeeded(subject, flags, to)
+	//   subject - entity number to flag
+	//   flags   - changed-field bits (shifted by SENDFLAGS_SHIFT on resend)
+	//   to      - 0 = broadcast, 1..N = specific client
+	unsigned int subject = (unsigned int)args[1];
+	// args[] are intptr_t and both VM backends sign-extend the mod's 32-bit
+	// value (vm_interpreted.c / vm_x86.c movsxd), so a mask with bit31 set must
+	// be re-cast to uint32_t first or it would pollute bits 32..63.
+	uint64_t fl = (uint64_t)(uint32_t)args[2] << SENDFLAGS_SHIFT;
+	unsigned int to = (unsigned int)args[3];
+
+	EXT_SetSendNeeded_Apply(subject, fl, to);
 	return 0;
 }
 
@@ -2056,21 +2082,7 @@ intptr_t EXT_SetSendNeeded64(intptr_t *args)
 	fl &= (SENDFLAGS_USABLE >> SENDFLAGS_SHIFT);
 	fl <<= SENDFLAGS_SHIFT;
 
-	if (!to)
-	{	// broadcast
-		unsigned int i;
-		for (i = 0; i < MAX_CLIENTS; i++)
-			if (svs.clients[i].pendingcsqcbits && subject < (unsigned int)svs.clients[i].max_net_ents)
-				svs.clients[i].pendingcsqcbits[subject] |= fl;
-	}
-	else
-	{
-		to--;
-		if (to >= MAX_CLIENTS || !svs.clients[to].pendingcsqcbits || subject >= (unsigned int)svs.clients[to].max_net_ents)
-			return 0;	// some kind of error.
-		else
-			svs.clients[to].pendingcsqcbits[subject] |= fl;
-	}
+	EXT_SetSendNeeded_Apply(subject, fl, to);
 	return 0;
 }
 

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1400,7 +1400,7 @@ void PF2_WriteString(int to, char *data)
 		sizebuf_t *dest = WriteDest2(to);
 		int len = (data && *data) ? (int)strlen(data) + 1 : 1;
 
-		// PR228-rev [14]: SZ_GetSpace Sys_Errors when a *single* write exceeds
+		// SZ_GetSpace Sys_Errors when a *single* write exceeds
 		// maxsize even with allowoverflow (csqcmsgbuffer is only MAX_DATAGRAM).
 		// Such a payload can never fit the client datagram anyway, so for
 		// allowoverflow destinations mark it overflowed and drop it instead of

--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -428,7 +428,9 @@ void PR2_LoadProgs(void)
 
 	if ( sv_vm )
 	{
-		; // nothing.
+#ifdef FTE_PEXT_CSQC
+		SV_ClearQCStats ();
+#endif
 	}
 	else
 	{

--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -517,46 +517,22 @@ qbool PR2_SendEntity(edict_t* e, edict_t* to, int sendflags)
 //===========================================================================
 // QCRequest (sendevent, client -> server)
 //
-// Writes the eventname string into mod memory (so the QVM mod can read it
-// back via PR2_GetString) and calls GAME_QCREQUEST. Argument values are
-// expected to already be in the parm slots of pr_global_struct (filled by
-// the caller, e.g. SV_ReadQCRequest). vm_str_off is the first free scratch
-// offset in the VM data area (after any string args the caller wrote);
-// 0 means "no string args were placed, use the default scratch start".
+// Calls GAME_QCREQUEST with arg0 = number of parsed args (self = the sending
+// client). The mod pulls the event name via trap_Argv(0) - the name is made
+// available as one raw argv by Cmd_SetRawArgv0 (no tokenization) - and typed
+// argument values via the qcrequestarg extension trap. No strings cross the
+// 32-bit VM_Call boundary, so this works on QVM and native alike.
 //===========================================================================
-void PR2_QCRequest(edict_t* cl_ent, const char* eventname, int argcount, int argtypes, unsigned int vm_str_off)
+void PR2_QCRequest(edict_t* cl_ent, int argcount)
 {
-	intptr_t name_off;
 	int old_self = pr_global_struct->self;
-	static char scratch[64];
 
-	if (!sv_vm || !eventname)
+	if (!sv_vm || !cl_ent)
 		return;
 
-	strlcpy(scratch, eventname, sizeof(scratch));
-
-	if (sv_vm->type == VMI_NATIVE)
-	{	// native: strings are host pointers, pass directly
-		name_off = (intptr_t)scratch;
-	}
-	else
-	{	// qvm: copy the string into the VM data area and pass its offset.
-		// exactDataLength is the end of the mod's declared data, with the
-		// PROGRAM_STACK_EXTRA reserved area after it - safe scratch for a
-		// short string (stack grows down from the top, bounded by stackBottom).
-		unsigned int off = vm_str_off ? vm_str_off : sv_vm->exactDataLength;
-		size_t len = strlen(scratch) + 1;
-
-		if (off + len > sv_vm->dataLength)
-		{	// shouldn't happen; bail out safely
-			return;
-		}
-		memcpy(sv_vm->dataBase + off, scratch, len);
-		name_off = off;
-	}
-
+	Cmd_SetRawArgv0(SV_QCRequestName());
 	pr_global_struct->self = EDICT_TO_PROG(cl_ent);
-	VM_Call(sv_vm, 3, GAME_QCREQUEST, (int)name_off, argcount, argtypes, 0, 0, 0, 0, 0, 0, 0, 0);
+	VM_Call(sv_vm, 1, GAME_QCREQUEST, argcount, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 	pr_global_struct->self = old_self;
 }
 #endif

--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -511,6 +511,50 @@ qbool PR2_SendEntity(edict_t* e, edict_t* to, int sendflags)
 	pr_global_struct->other = old_other;
 	return ret_val;
 }
+
+//===========================================================================
+// QCRequest (sendevent, client -> server)
+//
+// Writes the eventname string into mod memory (so the QVM mod can read it
+// back via PR2_GetString) and calls GAME_QCREQUEST. Argument values are
+// expected to already be in the parm slots of pr_global_struct (filled by
+// the caller, e.g. SV_ReadQCRequest).
+//===========================================================================
+void PR2_QCRequest(edict_t* cl_ent, const char* eventname, int argcount, int argtypes)
+{
+	intptr_t name_off;
+	int old_self = pr_global_struct->self;
+	static char scratch[64];
+
+	if (!sv_vm || !eventname)
+		return;
+
+	strlcpy(scratch, eventname, sizeof(scratch));
+
+	if (sv_vm->type == VMI_NATIVE)
+	{	// native: strings are host pointers, pass directly
+		name_off = (intptr_t)scratch;
+	}
+	else
+	{	// qvm: copy the string into the VM data area and pass its offset.
+		// exactDataLength is the end of the mod's declared data, with the
+		// PROGRAM_STACK_EXTRA reserved area after it - safe scratch for a
+		// short string (stack grows down from the top, bounded by stackBottom).
+		unsigned int off = sv_vm->exactDataLength;
+		size_t len = strlen(scratch) + 1;
+
+		if (off + len > sv_vm->dataLength)
+		{	// shouldn't happen; bail out safely
+			return;
+		}
+		memcpy(sv_vm->dataBase + off, scratch, len);
+		name_off = off;
+	}
+
+	pr_global_struct->self = EDICT_TO_PROG(cl_ent);
+	VM_Call(sv_vm, 3, GAME_QCREQUEST, (int)name_off, argcount, argtypes, 0, 0, 0, 0, 0, 0, 0, 0);
+	pr_global_struct->self = old_self;
+}
 #endif
 
 //===========================================================================

--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -518,9 +518,11 @@ qbool PR2_SendEntity(edict_t* e, edict_t* to, int sendflags)
 // Writes the eventname string into mod memory (so the QVM mod can read it
 // back via PR2_GetString) and calls GAME_QCREQUEST. Argument values are
 // expected to already be in the parm slots of pr_global_struct (filled by
-// the caller, e.g. SV_ReadQCRequest).
+// the caller, e.g. SV_ReadQCRequest). vm_str_off is the first free scratch
+// offset in the VM data area (after any string args the caller wrote);
+// 0 means "no string args were placed, use the default scratch start".
 //===========================================================================
-void PR2_QCRequest(edict_t* cl_ent, const char* eventname, int argcount, int argtypes)
+void PR2_QCRequest(edict_t* cl_ent, const char* eventname, int argcount, int argtypes, unsigned int vm_str_off)
 {
 	intptr_t name_off;
 	int old_self = pr_global_struct->self;
@@ -540,7 +542,7 @@ void PR2_QCRequest(edict_t* cl_ent, const char* eventname, int argcount, int arg
 		// exactDataLength is the end of the mod's declared data, with the
 		// PROGRAM_STACK_EXTRA reserved area after it - safe scratch for a
 		// short string (stack grows down from the top, bounded by stackBottom).
-		unsigned int off = sv_vm->exactDataLength;
+		unsigned int off = vm_str_off ? vm_str_off : sv_vm->exactDataLength;
 		size_t len = strlen(scratch) + 1;
 
 		if (off + len > sv_vm->dataLength)

--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -498,7 +498,7 @@ void PR2_ClearEdict(edict_t* e)
 //===========================================================================
 // SendEntity
 //===========================================================================
-qbool PR2_SendEntity(edict_t* e, edict_t* to, int sendflags)
+qbool PR2_SendEntity(edict_t* e, edict_t* to, uint64_t sendflags)
 {
 	qbool ret_val = false;
 	int old_self = pr_global_struct->self;
@@ -507,7 +507,9 @@ qbool PR2_SendEntity(edict_t* e, edict_t* to, int sendflags)
 	pr_global_struct->other = to ? EDICT_TO_PROG(to) : 0;
 	if (sv_vm)
 	{
-		ret_val = VM_Call(sv_vm, 1, GAME_EDICT_CSQCSEND, (int)sendflags, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+		// QVM/native границы 32-битны: 64-битная маска идёт двумя int
+		// (lo = биты 0..31, hi = биты 32..61; PRESENT/REMOVED остаются в движке).
+		ret_val = VM_Call(sv_vm, 2, GAME_EDICT_CSQCSEND, (int)(uint32_t)sendflags, (int)(sendflags >> 32), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 	}
 	pr_global_struct->self = old_self;
 	pr_global_struct->other = old_other;

--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -507,8 +507,8 @@ qbool PR2_SendEntity(edict_t* e, edict_t* to, uint64_t sendflags)
 	pr_global_struct->other = to ? EDICT_TO_PROG(to) : 0;
 	if (sv_vm)
 	{
-		// QVM/native границы 32-битны: 64-битная маска идёт двумя int
-		// (lo = биты 0..31, hi = биты 32..61; PRESENT/REMOVED остаются в движке).
+		// QVM/native word sizes are 32-bit: the 64-bit mask goes as two ints
+		// (lo = bits 0..31, hi = bits 32..61; PRESENT/REMOVED stay engine-side).
 		ret_val = VM_Call(sv_vm, 2, GAME_EDICT_CSQCSEND, (int)(uint32_t)sendflags, (int)(sendflags >> 32), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 	}
 	pr_global_struct->self = old_self;

--- a/src/pr_edict.c
+++ b/src/pr_edict.c
@@ -1246,6 +1246,12 @@ void PR1_LoadProgs (void)
 	for (i = 0; i < progs->numglobals; i++)
 		((int *)pr_globals)[i] = LittleLong (((int *)pr_globals)[i]);
 
+#ifdef FTE_PEXT_CSQC
+	// fresh progs image: registered csqc stats (pointerstat pointers into the
+	// old progs memory) are invalid now
+	SV_ClearQCStats ();
+#endif
+
 	PR_InitBuiltins();
 }
 

--- a/src/progs.h
+++ b/src/progs.h
@@ -69,6 +69,7 @@ typedef struct
 	float	colourmod[3];	// r,g,b [0.0 .. 1.0], > 1 overbright
 #ifdef FTE_PEXT_CSQC
 	int		sendentity;		// Trigger GAME_CSQCSEND indirection
+	float	sendflags;		// CSQC changed-flags to resend (cleared by SV_CleanupEnts)
 	float	pvsflags;		// CSQC pvsflags
 #endif
 } ext_entvars_t;

--- a/src/progs.h
+++ b/src/progs.h
@@ -69,7 +69,7 @@ typedef struct
 	float	colourmod[3];	// r,g,b [0.0 .. 1.0], > 1 overbright
 #ifdef FTE_PEXT_CSQC
 	int		sendentity;		// Trigger GAME_CSQCSEND indirection
-	float	sendflags;		// CSQC changed-flags to resend (cleared by SV_CleanupEnts)
+	float	sendflags[3];	// QC vector SendFlags, 3 x 24 bits (cleared by SV_CleanupEnts)
 	float	pvsflags;		// CSQC pvsflags
 #endif
 } ext_entvars_t;

--- a/src/server.h
+++ b/src/server.h
@@ -168,6 +168,8 @@ typedef struct
 
 // sv_ents.c
 extern sizebuf_t csqcmsgbuffer;
+// sv_main.c
+extern cvar_t sv_csqcdebug;
 // sv_send.c
 void SV_ClearQCStats (void);
 void SV_QCStatFieldIdx (int type, unsigned int fieldindex, int statnum);

--- a/src/server.h
+++ b/src/server.h
@@ -169,6 +169,7 @@ typedef struct
 // sv_ents.c
 extern sizebuf_t csqcmsgbuffer;
 // sv_send.c
+void SV_ClearQCStats (void);
 void SV_QCStatFieldIdx (int type, unsigned int fieldindex, int statnum);
 void SV_QCStatPtr (int type, void *ptr, int statnum);
 void SV_QCStatGlobal (int type, const char *name, int statnum);

--- a/src/server.h
+++ b/src/server.h
@@ -168,6 +168,10 @@ typedef struct
 
 // sv_ents.c
 extern sizebuf_t csqcmsgbuffer;
+// sv_send.c
+void SV_QCStatFieldIdx (int type, unsigned int fieldindex, int statnum);
+void SV_QCStatPtr (int type, void *ptr, int statnum);
+void SV_QCStatGlobal (int type, const char *name, int statnum);
 #endif
 
 #define	NUM_SPAWN_PARMS 16

--- a/src/server.h
+++ b/src/server.h
@@ -133,6 +133,20 @@ typedef struct
 #endif
 } server_t;
 
+#ifdef FTE_PEXT_CSQC
+#define MSG_CSQC		5		// for csqc (pr2_cmds.c WriteDest2)
+
+// per-entity CSQC delta flags, mirror of FTE server.h SENDFLAGS_*
+#define SENDFLAGS_PRESENT	0x1u	// this entity is present on that client
+#define SENDFLAGS_REMOVED	0x2u	// to handle remove packetloss
+#define SENDFLAGS_RESERVED	(SENDFLAGS_PRESENT|SENDFLAGS_REMOVED)
+#define SENDFLAGS_SHIFT		2u
+#define SENDFLAGS_USABLE	(~(uint64_t)SENDFLAGS_RESERVED)	// bits actually safe in a float
+
+// CSQC pvsflags bit
+#define PVSF_NOREMOVE		0x80
+#endif
+
 #define	NUM_SPAWN_PARMS 16
 
 // { sv_antilag related

--- a/src/server.h
+++ b/src/server.h
@@ -117,7 +117,7 @@ typedef struct
 
 	// the signon buffer will be sent to each client as they connect
 	// includes the entity baselines, the static entities, etc
-	// large levels will have >MAX_DATAGRAM sized signons, so 
+	// large levels will have >MAX_DATAGRAM sized signons, so
 	// multiple signon messages are kept
 	sizebuf_t      signon;
 	unsigned int   num_signon_buffers;
@@ -134,25 +134,6 @@ typedef struct
 } server_t;
 
 #ifdef FTE_PEXT_CSQC
-// CSQC wire message numbers. Not in the qwprot revision mvdsv pins (master
-// still labels 83 as the dead svc_qizmovoice and has no CSQC game-packet/
-// qcrequest messages, and svc_fte_csqcentities_sized is a later upstream
-// addition), so they live here. Numbering matches FTE (fteqw engine/common/
-// protocol.h: svcfte_cgamepacket 83, svcfte_cgamepacket_sized 90,
-// clcfte_qcrequest 81; svc_fte_csqcentities_sized 92).
-// #ifndef guards keep this compiling once upstream qwprot defines the names.
-#ifndef svc_fte_csqcentities_sized
-#define svc_fte_csqcentities_sized	92	// as svc_fte_csqcentities, with a length prefix per update (sv_csqcdebug)
-#endif
-#ifndef svc_fte_cgamepacket
-#define svc_fte_cgamepacket		83	// ssqc->csqc game packets, only via multicast
-#endif
-#ifndef svc_fte_cgamepacket_sized
-#define svc_fte_cgamepacket_sized	90	// cgamepacket with a short length prefix (sv_csqcdebug)
-#endif
-#ifndef clcfte_qcrequest
-#define clcfte_qcrequest	81	// CSQC sendevent (client -> server)
-#endif
 
 #define MSG_CSQC		5		// for csqc (pr2_cmds.c WriteDest2)
 
@@ -1138,15 +1119,15 @@ void SV_Heartbeat_f (void);
 void Master_Shutdown (void);
 void Master_Heartbeat (void);
 
-// sv_save.c 
-void SV_SaveGame_f (void); 
-void SV_LoadGame_f (void); 
+// sv_save.c
+void SV_SaveGame_f (void);
+void SV_LoadGame_f (void);
 
 //
 void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, sizebuf_t *msg, qbool force);
 qbool SV_SkipCommsBotMessage(client_t* client);
 
-// 
+//
 #ifdef SERVERONLY
 #include "central.h"
 #else

--- a/src/server.h
+++ b/src/server.h
@@ -170,6 +170,9 @@ typedef struct
 extern sizebuf_t csqcmsgbuffer;
 // sv_main.c
 extern cvar_t sv_csqcdebug;
+// sv_init.c
+qbool SV_CSQCActive (void);   // true if a PR2 mod (native/QVM) is loaded; PR1 (.dat) -> false
+void SV_UpdateCSQCExtension (void); // set/clear FTE_PEXT_CSQC in svs.fteprotocolextensions by mod type
 // sv_send.c
 void SV_ClearQCStats (void);
 void SV_QCStatFieldIdx (int type, unsigned int fieldindex, int statnum);

--- a/src/server.h
+++ b/src/server.h
@@ -179,6 +179,9 @@ void SV_QCStatFieldIdx (int type, unsigned int fieldindex, int statnum);
 void SV_QCStatPtr (int type, void *ptr, int statnum);
 void SV_QCStatGlobal (int type, const char *name, int statnum);
 void SV_UpdateQCStats (edict_t *ent, int *stats);
+// sv_user.c - state of the qcrequest (sendevent) currently being dispatched
+const char *SV_QCRequestName (void);	// event name (via trap_Argv(0) in the game)
+int SV_QCRequestArg (int idx, void *dst, size_t dstsize);	// copies arg, returns QCREQ_T_* / -1
 #endif
 
 #define	NUM_SPAWN_PARMS 16

--- a/src/server.h
+++ b/src/server.h
@@ -172,6 +172,7 @@ extern sizebuf_t csqcmsgbuffer;
 void SV_QCStatFieldIdx (int type, unsigned int fieldindex, int statnum);
 void SV_QCStatPtr (int type, void *ptr, int statnum);
 void SV_QCStatGlobal (int type, const char *name, int statnum);
+void SV_UpdateQCStats (edict_t *ent, int *stats);
 #endif
 
 #define	NUM_SPAWN_PARMS 16

--- a/src/server.h
+++ b/src/server.h
@@ -134,6 +134,26 @@ typedef struct
 } server_t;
 
 #ifdef FTE_PEXT_CSQC
+// CSQC wire message numbers. Not in the qwprot revision mvdsv pins (master
+// still labels 83 as the dead svc_qizmovoice and has no CSQC game-packet/
+// qcrequest messages, and svc_fte_csqcentities_sized is a later upstream
+// addition), so they live here. Numbering matches FTE (fteqw engine/common/
+// protocol.h: svcfte_cgamepacket 83, svcfte_cgamepacket_sized 90,
+// clcfte_qcrequest 81; svc_fte_csqcentities_sized 92).
+// #ifndef guards keep this compiling once upstream qwprot defines the names.
+#ifndef svc_fte_csqcentities_sized
+#define svc_fte_csqcentities_sized	92	// as svc_fte_csqcentities, with a length prefix per update (sv_csqcdebug)
+#endif
+#ifndef svc_fte_cgamepacket
+#define svc_fte_cgamepacket		83	// ssqc->csqc game packets, only via multicast
+#endif
+#ifndef svc_fte_cgamepacket_sized
+#define svc_fte_cgamepacket_sized	90	// cgamepacket with a short length prefix (sv_csqcdebug)
+#endif
+#ifndef clcfte_qcrequest
+#define clcfte_qcrequest	81	// CSQC sendevent (client -> server)
+#endif
+
 #define MSG_CSQC		5		// for csqc (pr2_cmds.c WriteDest2)
 
 // per-entity CSQC delta flags, mirror of FTE server.h SENDFLAGS_*
@@ -145,6 +165,9 @@ typedef struct
 
 // CSQC pvsflags bit
 #define PVSF_NOREMOVE		0x80
+
+// sv_ents.c
+extern sizebuf_t csqcmsgbuffer;
 #endif
 
 #define	NUM_SPAWN_PARMS 16
@@ -364,6 +387,8 @@ typedef struct client_s
 
 #ifdef FTE_PEXT_CSQC
 	qbool			csqcactive;
+	uint64_t		*pendingcsqcbits;	// per-entity CSQC delta bits, size max_net_ents
+	int				max_net_ents;		// actual size of pendingcsqcbits
 #endif
 
 	//===== NETWORK ============
@@ -412,6 +437,12 @@ typedef struct client_s
 		float    last_sidemove;     // Previous frame's sidemove value
 	} safestrafe;
 } client_t;
+
+#ifdef FTE_PEXT_CSQC
+// sv_ents.c
+void SV_ProcessSendFlags (client_t *c);
+void SV_CleanupEnts (void);
+#endif
 
 // a client can leave the server in one of four ways:
 // dropping properly by quiting or disconnecting

--- a/src/server.h
+++ b/src/server.h
@@ -144,6 +144,13 @@ typedef struct
 #define SENDFLAGS_SHIFT		2u
 #define SENDFLAGS_USABLE	(~(uint64_t)SENDFLAGS_RESERVED)	// bits actually safe in a float
 
+// per-frame CSQC resend log: which entities were updated into which outgoing
+// datagram, so a lost packet re-flags them for a full resend (FTE
+// SV_CSQC_DroppedPacket). Only the entity number is stored - on drop the
+// entity is OR'ed with SENDFLAGS_USABLE (simpler and always correct).
+#define CSQC_LOG_MAX		64
+typedef unsigned short	csqc_log_t;
+
 // CSQC pvsflags bit
 #define PVSF_NOREMOVE		0x80
 
@@ -198,6 +205,16 @@ typedef struct
 // }
 
 	packet_entities_t	entities;
+
+#ifdef FTE_PEXT_CSQC
+	// outgoing sequence this frame was built for (0 if unused); lets
+	// SV_CSQC_DroppedPacket skip stale slots (FTE checks frame->sequence).
+	int				sequence;
+	// CSQC entities emitted in this frame's datagram (see CSQC_LOG_MAX).
+	int				csqc_lognum;
+	qbool			csqc_log_overflow;
+	csqc_log_t		csqc_log[CSQC_LOG_MAX];
+#endif
 } client_frame_t;
 
 typedef struct
@@ -384,6 +401,7 @@ typedef struct client_s
 	qbool			csqcactive;
 	uint64_t		*pendingcsqcbits;	// per-entity CSQC delta bits, size max_net_ents
 	int				max_net_ents;		// actual size of pendingcsqcbits
+	int				csqc_lastack;		// last outgoing seq known acknowledged (loss recovery)
 #endif
 
 	//===== NETWORK ============
@@ -836,6 +854,12 @@ typedef struct
 void SV_Frame (double time);
 void SV_FinalMessage (const char *message);
 void SV_DropClient (client_t *drop);
+
+#ifdef FTE_PEXT_CSQC
+// sv_ents.c - CSQC loss recovery (FTE SV_AckEntityFrame / SV_CSQC_DroppedPacket)
+void SV_AckEntityFrame (client_t *client, int framenum);
+void SV_CSQC_DroppedPacket (client_t *client, int sequence);
+#endif
 
 int SV_CalcPing (client_t *cl);
 void SV_FullClientUpdate (client_t *client, sizebuf_t *buf);

--- a/src/server.h
+++ b/src/server.h
@@ -137,6 +137,18 @@ typedef struct
 
 #define MSG_CSQC		5		// for csqc (pr2_cmds.c WriteDest2)
 
+// CSQC stat wire opcodes for fractional/string stats (PR228 rev [18]).
+// FTE defines svcfte_updatestatstring/updatestatfloat as 78/79; upstream
+// qwprot/ezQuake do not, so mvdsv currently truncates such stats to int in
+// SV_UpdateQCStats. Define them locally (guarded) so the float/string emit
+// path can light up once qwprot carries them, without colliding meanwhile.
+#ifndef svcfte_updatestatstring
+#define svcfte_updatestatstring	78	// [byte statnum] [string]
+#endif
+#ifndef svcfte_updatestatfloat
+#define svcfte_updatestatfloat	79	// [byte statnum] [float]
+#endif
+
 // per-entity CSQC delta flags, mirror of FTE server.h SENDFLAGS_*
 #define SENDFLAGS_PRESENT	0x1u	// this entity is present on that client
 #define SENDFLAGS_REMOVED	0x2u	// to handle remove packetloss
@@ -859,6 +871,8 @@ void SV_DropClient (client_t *drop);
 // sv_ents.c - CSQC loss recovery (FTE SV_AckEntityFrame / SV_CSQC_DroppedPacket)
 void SV_AckEntityFrame (client_t *client, int framenum);
 void SV_CSQC_DroppedPacket (client_t *client, int sequence);
+// sv_send.c - emit CSQC stats 32..127 to this destination (live client / recorder)
+qbool SV_WantsQCStats (client_t *client);
 #endif
 
 int SV_CalcPing (client_t *cl);

--- a/src/server.h
+++ b/src/server.h
@@ -164,7 +164,13 @@ typedef struct
 typedef unsigned short	csqc_log_t;
 #define CSQC_LOG_REMOVE		0x8000	// entry flag: this logged update was a remove
 
-// CSQC pvsflags bit
+// CSQC pvsflags (FTE server.h): the low 2 bits select the visibility mode,
+// 0x80 suppresses the automatic remove when the entity leaves the PVS.
+#define PVSF_NORMALPVS		0x0
+#define PVSF_NOTRACECHECK	0x1
+#define PVSF_USEPHS			0x2
+#define PVSF_IGNOREPVS		0x3
+#define PVSF_MODE_MASK		0x3
 #define PVSF_NOREMOVE		0x80
 
 // sv_ents.c

--- a/src/server.h
+++ b/src/server.h
@@ -114,6 +114,13 @@ typedef struct
 	// the multicast buffer is used to send a message to a set of clients
 	sizebuf_t	multicast;
 	byte		multicast_buf[MAX_MSGLEN];
+#ifdef FTE_PEXT_CSQC
+	// set when a mod's multicast starts with svc_fte_cgamepacket (the first
+	// byte of a fresh buffer); PF2_multicast then dispatches it through
+	// SV_CSQCMulticast so only CSQC clients receive it. Cleared on every
+	// multicast dispatch.
+	qbool		multicast_csqc;
+#endif
 
 	// the signon buffer will be sent to each client as they connect
 	// includes the entity baselines, the static entities, etc
@@ -987,6 +994,10 @@ qbool SV_AddToRedirect(char *msg);
 
 void SV_Multicast(vec3_t origin, int to);
 void SV_MulticastEx(vec3_t origin, int to, const char *cl_reliable_key);
+#ifdef FTE_PEXT_CSQC
+// dispatch a mod's CSQC multicast (svc_fte_cgamepacket) to CSQC clients only
+void SV_CSQCMulticast(vec3_t origin, int to);
+#endif
 void SV_StartParticle(vec3_t org, vec3_t dir, int color, int count, int replacement_te, int replacement_count);
 void SV_StartSound(edict_t *entity, int channel, char *sample, int volume, float attenuation);
 void SV_ClientPrintf(client_t *cl, int level, char *fmt, ...);

--- a/src/server.h
+++ b/src/server.h
@@ -137,11 +137,11 @@ typedef struct
 
 #define MSG_CSQC		5		// for csqc (pr2_cmds.c WriteDest2)
 
-// CSQC stat wire opcodes for fractional/string stats (PR228 rev [18]).
+// CSQC stat wire opcodes for fractional/string stats.
 // FTE defines svcfte_updatestatstring/updatestatfloat as 78/79; upstream
-// qwprot/ezQuake do not, so mvdsv currently truncates such stats to int in
-// SV_UpdateQCStats. Define them locally (guarded) so the float/string emit
-// path can light up once qwprot carries them, without colliding meanwhile.
+// qwprot/ezQuake do not carry them yet, so define them locally (guarded).
+// mvdsv emits them (live clients and, under sv_mvd_csqc, MVD/QTV); only the
+// client-side receive path is pending on qwprot/ezQuake.
 #ifndef svcfte_updatestatstring
 #define svcfte_updatestatstring	78	// [byte statnum] [string]
 #endif
@@ -181,7 +181,7 @@ void SV_QCStatFieldIdx (int type, unsigned int fieldindex, int statnum);
 void SV_QCStatPtr (int type, void *ptr, int statnum);
 void SV_QCStatGlobal (int type, const char *name, int statnum);
 void SV_UpdateQCStats (edict_t *ent, int *statsi, float *statsf, const char **statss);
-// CSQC stat wire kinds (PR228 [18]): drives the emit opcode for a statnum
+// CSQC stat wire kinds: drives the emit opcode for a statnum
 #define QCSTAT_KIND_INT		0
 #define QCSTAT_KIND_FLOAT	1
 #define QCSTAT_KIND_STRING	2
@@ -330,7 +330,7 @@ typedef struct client_s
 	int				stats[MAX_CL_STATS];
 
 #ifdef FTE_PEXT_CSQC
-	float			statsf[MAX_CL_STATS];	// last emitted float stat value (PR228 [18])
+	float			statsf[MAX_CL_STATS];	// last emitted float stat value
 	char			*statss[MAX_CL_STATS];	// last emitted string stat (host copy, Q_strdup)
 #endif
 

--- a/src/server.h
+++ b/src/server.h
@@ -168,6 +168,7 @@ typedef unsigned short	csqc_log_t;
 
 // sv_ents.c
 extern sizebuf_t csqcmsgbuffer;
+void SV_FreeCSQCList (void);   // release the per-frame CSQC PVS entity list
 // sv_main.c
 extern cvar_t sv_csqcdebug;
 // sv_init.c

--- a/src/server.h
+++ b/src/server.h
@@ -157,11 +157,12 @@ typedef struct
 #define SENDFLAGS_USABLE	(~(uint64_t)SENDFLAGS_RESERVED)	// bits actually safe in a float
 
 // per-frame CSQC resend log: which entities were updated into which outgoing
-// datagram, so a lost packet re-flags them for a full resend (FTE
-// SV_CSQC_DroppedPacket). Only the entity number is stored - on drop the
-// entity is OR'ed with SENDFLAGS_USABLE (simpler and always correct).
+// datagram, so a lost packet re-flags them (FTE SV_CSQC_DroppedPacket). Each
+// entry stores the entity number plus CSQC_LOG_REMOVE; on drop the entity is
+// OR'ed with SENDFLAGS_REMOVED (a lost remove) or SENDFLAGS_USABLE (a send).
 #define CSQC_LOG_MAX		64
 typedef unsigned short	csqc_log_t;
+#define CSQC_LOG_REMOVE		0x8000	// entry flag: this logged update was a remove
 
 // CSQC pvsflags bit
 #define PVSF_NOREMOVE		0x80

--- a/src/server.h
+++ b/src/server.h
@@ -180,7 +180,12 @@ void SV_ClearQCStats (void);
 void SV_QCStatFieldIdx (int type, unsigned int fieldindex, int statnum);
 void SV_QCStatPtr (int type, void *ptr, int statnum);
 void SV_QCStatGlobal (int type, const char *name, int statnum);
-void SV_UpdateQCStats (edict_t *ent, int *stats);
+void SV_UpdateQCStats (edict_t *ent, int *statsi, float *statsf, const char **statss);
+// CSQC stat wire kinds (PR228 [18]): drives the emit opcode for a statnum
+#define QCSTAT_KIND_INT		0
+#define QCSTAT_KIND_FLOAT	1
+#define QCSTAT_KIND_STRING	2
+int SV_QCStatKind (int statnum);
 // sv_user.c - state of the qcrequest (sendevent) currently being dispatched
 const char *SV_QCRequestName (void);	// event name (via trap_Argv(0) in the game)
 int SV_QCRequestArg (int idx, void *dst, size_t dstsize);	// copies arg, returns QCREQ_T_* / -1
@@ -323,6 +328,11 @@ typedef struct client_s
 	int				old_frags;
 
 	int				stats[MAX_CL_STATS];
+
+#ifdef FTE_PEXT_CSQC
+	float			statsf[MAX_CL_STATS];	// last emitted float stat value (PR228 [18])
+	char			*statss[MAX_CL_STATS];	// last emitted string stat (host copy, Q_strdup)
+#endif
 
 	double			lastservertimeupdate;		// last realtime we sent STAT_TIME to the client
 
@@ -601,6 +611,11 @@ typedef struct
 	qbool			fixangle[MAX_CLIENTS];
 
 	int				stats[MAX_CLIENTS][MAX_CL_STATS];
+
+#ifdef FTE_PEXT_CSQC
+	float			statsf[MAX_CLIENTS][MAX_CL_STATS];
+	char			*statss[MAX_CLIENTS][MAX_CL_STATS];
+#endif
 
 	int				parsecount;  // current frame, to which we add demo data
 	int				lastwritten; // lastwriten frame

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1658,7 +1658,8 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 		stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 
 #ifdef FTE_PEXT_CSQC
-		// clientstat/pointerstat registered stats (32..127), recorder will get FTE_PEXT_CSQC in phase 6
+		// clientstat/pointerstat registered stats (32..127) - only for the
+		// MVD recorder, which has FTE_PEXT_CSQC set while recording
 		if (demo.recorder.fteprotocolextensions & FTE_PEXT_CSQC)
 			SV_UpdateQCStats (ent, stats);
 #endif

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1636,6 +1636,12 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 		// stuff the sigil bits into the high bits of items for sbar
 		stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 
+#ifdef FTE_PEXT_CSQC
+		// clientstat/pointerstat registered stats (32..127), recorder will get FTE_PEXT_CSQC in phase 6
+		if (demo.recorder.fteprotocolextensions & FTE_PEXT_CSQC)
+			SV_UpdateQCStats (ent, stats);
+#endif
+
 		for (j = 0; j < MAX_CL_STATS; j++)
 		{
 			if (stats[j] >= 0 && stats[j] <= 255)

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1659,7 +1659,8 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 
 #ifdef FTE_PEXT_CSQC
 		// clientstat/pointerstat registered stats (32..127) - only for the
-		// MVD recorder, which has FTE_PEXT_CSQC set while recording
+		// MVD recorder, which has FTE_PEXT_CSQC set while recording.
+		// TODO (F13): same csqcactive-vs-ext gate question as SV_UpdateClientStats.
 		if (demo.recorder.fteprotocolextensions & FTE_PEXT_CSQC)
 			SV_UpdateQCStats (ent, stats);
 #endif

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1003,6 +1003,17 @@ void SV_MVDStop (int reason, qbool mvdonly)
 	instop = false; // SET TO FALSE
 
 out:
+#ifdef FTE_PEXT_CSQC
+	// the recorder struct is memset on the next fresh record start, so free
+	// the CSQC delta bitset here to avoid leaking it
+	if (demo.recorder.pendingcsqcbits)
+	{
+		Q_free(demo.recorder.pendingcsqcbits);
+		demo.recorder.pendingcsqcbits = NULL;
+	}
+	demo.recorder.max_net_ents = 0;
+	demo.recorder.csqcactive = false;
+#endif
 	if (reason != 3)
 		SV_BroadcastPrintCache();
 }
@@ -1239,6 +1250,16 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 #endif
 #ifdef FTE_PEXT_COLOURMOD
 	demo.recorder.fteprotocolextensions |= FTE_PEXT_COLOURMOD;
+#endif
+#ifdef FTE_PEXT_CSQC
+	demo.recorder.fteprotocolextensions |= FTE_PEXT_CSQC;
+	demo.recorder.csqcactive = true;
+	// lazily allocate the recorder's CSQC delta bitset
+	if (!demo.recorder.pendingcsqcbits && sv.max_edicts > 0)
+	{
+		demo.recorder.pendingcsqcbits = Q_calloc(sv.max_edicts, sizeof(uint64_t));
+		demo.recorder.max_net_ents = sv.max_edicts;
+	}
 #endif
 #ifdef FTE_PEXT2_VOICECHAT
 	demo.recorder.fteprotocolextensions2 |= FTE_PEXT2_VOICECHAT;

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1252,13 +1252,16 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 	demo.recorder.fteprotocolextensions |= FTE_PEXT_COLOURMOD;
 #endif
 #ifdef FTE_PEXT_CSQC
-	demo.recorder.fteprotocolextensions |= FTE_PEXT_CSQC;
-	demo.recorder.csqcactive = true;
-	// lazily allocate the recorder's CSQC delta bitset
-	if (!demo.recorder.pendingcsqcbits && sv.max_edicts > 0)
+	if (SV_CSQCActive())
 	{
-		demo.recorder.pendingcsqcbits = Q_calloc(sv.max_edicts, sizeof(uint64_t));
-		demo.recorder.max_net_ents = sv.max_edicts;
+		demo.recorder.fteprotocolextensions |= FTE_PEXT_CSQC;
+		demo.recorder.csqcactive = true;
+		// lazily allocate the recorder's CSQC delta bitset
+		if (!demo.recorder.pendingcsqcbits && sv.max_edicts > 0)
+		{
+			demo.recorder.pendingcsqcbits = Q_calloc(sv.max_edicts, sizeof(uint64_t));
+			demo.recorder.max_net_ents = sv.max_edicts;
+		}
 	}
 #endif
 #ifdef FTE_PEXT2_VOICECHAT

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1667,6 +1667,7 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 	{
 		int		stats[MAX_CL_STATS];
 		int		j;
+		int		n;
 
 		player = svs.clients + i;
 		ent = player->edict;
@@ -1701,7 +1702,14 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 			SV_UpdateQCStats (ent, stats);
 #endif
 
-		for (j = 0; j < MAX_CL_STATS; j++)
+		// legacy 32 stats unless the recorder is explicitly CSQC (PR228 rev [1])
+#ifdef FTE_PEXT_CSQC
+		n = SV_WantsQCStats (&demo.recorder) ? MAX_CL_STATS : MAX_WIRE_STATS;
+#else
+		n = MAX_WIRE_STATS;
+#endif
+
+		for (j = 0; j < n; j++)
 		{
 			if (stats[j] >= 0 && stats[j] <= 255)
 			{

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -927,6 +927,7 @@ SV_MVD_Record before it partial-memsets the demo struct on a fresh start.
 static void SV_MVD_FreeRecorderCSQC (void)
 {
 #ifdef FTE_PEXT_CSQC
+	int i, j;
 	if (demo.recorder.pendingcsqcbits)
 	{
 		Q_free(demo.recorder.pendingcsqcbits);
@@ -934,6 +935,10 @@ static void SV_MVD_FreeRecorderCSQC (void)
 	}
 	demo.recorder.max_net_ents = 0;
 	demo.recorder.csqcactive = false;
+	// free the recorder's cached string stats (host copies, PR228 [18])
+	for (i = 0; i < MAX_CLIENTS; i++)
+		for (j = 0; j < MAX_CL_STATS; j++)
+			Q_free(demo.statss[i][j]);
 #endif
 }
 
@@ -1665,9 +1670,13 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 	// send stats
 	for (i = 0; i < MAX_CLIENTS; i++)
 	{
-		int		stats[MAX_CL_STATS];
+		int		statsi[MAX_CL_STATS];
 		int		j;
 		int		n;
+#ifdef FTE_PEXT_CSQC
+		float	statsf[MAX_CL_STATS];
+		const char *statss[MAX_CL_STATS];
+#endif
 
 		player = svs.clients + i;
 		ent = player->edict;
@@ -1678,28 +1687,32 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 		if (player->spectator)
 			continue;
 
-		memset(stats, 0, sizeof(stats));
+		memset(statsi, 0, sizeof(statsi));
+#ifdef FTE_PEXT_CSQC
+		memset(statsf, 0, sizeof(statsf));
+		memset(statss, 0, sizeof(statss));
+#endif
 
-		stats[STAT_HEALTH]       = ent->v->health;
-		stats[STAT_WEAPON]       = SV_ModelIndex(PR_GetEntityString(ent->v->weaponmodel));
-		stats[STAT_AMMO]         = ent->v->currentammo;
-		stats[STAT_ARMOR]        = ent->v->armorvalue;
-		stats[STAT_SHELLS]       = ent->v->ammo_shells;
-		stats[STAT_NAILS]        = ent->v->ammo_nails;
-		stats[STAT_ROCKETS]      = ent->v->ammo_rockets;
-		stats[STAT_CELLS]        = ent->v->ammo_cells;
-		stats[STAT_ACTIVEWEAPON] = ent->v->weapon;
+		statsi[STAT_HEALTH]       = ent->v->health;
+		statsi[STAT_WEAPON]       = SV_ModelIndex(PR_GetEntityString(ent->v->weaponmodel));
+		statsi[STAT_AMMO]         = ent->v->currentammo;
+		statsi[STAT_ARMOR]        = ent->v->armorvalue;
+		statsi[STAT_SHELLS]       = ent->v->ammo_shells;
+		statsi[STAT_NAILS]        = ent->v->ammo_nails;
+		statsi[STAT_ROCKETS]      = ent->v->ammo_rockets;
+		statsi[STAT_CELLS]        = ent->v->ammo_cells;
+		statsi[STAT_ACTIVEWEAPON] = ent->v->weapon;
 
 		if (ent->v->health > 0) // viewheight for PF_DEAD & PF_GIB is hardwired
-			stats[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
+			statsi[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
 
 		// stuff the sigil bits into the high bits of items for sbar
-		stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
+		statsi[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 
 #ifdef FTE_PEXT_CSQC
 		// clientstat/pointerstat registered stats (32..127) for the recorder.
 		if (SV_WantsQCStats (&demo.recorder))
-			SV_UpdateQCStats (ent, stats);
+			SV_UpdateQCStats (ent, statsi, statsf, statss);
 #endif
 
 		// legacy 32 stats unless the recorder is explicitly CSQC (PR228 rev [1])
@@ -1711,17 +1724,49 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 
 		for (j = 0; j < n; j++)
 		{
-			if (stats[j] >= 0 && stats[j] <= 255)
+#ifdef FTE_PEXT_CSQC
+			// PR228 rev [18]: float/string stats use their own wire opcodes
+			if (SV_QCStatKind(j) == QCSTAT_KIND_FLOAT)
+			{
+				if (statsf[j] && statsf[j] != (float)(int)statsf[j])
+				{
+					MSG_WriteByte(&buf, svcfte_updatestatfloat);
+					MSG_WriteByte(&buf, j);
+					MSG_WriteFloat(&buf, statsf[j]);
+				}
+				else if ((int)statsf[j] >= 0 && (int)statsf[j] <= 255)
+				{
+					MSG_WriteByte(&buf, svc_updatestat);
+					MSG_WriteByte(&buf, j);
+					MSG_WriteByte(&buf, (int)statsf[j]);
+				}
+				else
+				{
+					MSG_WriteByte(&buf, svc_updatestatlong);
+					MSG_WriteByte(&buf, j);
+					MSG_WriteLong(&buf, (int)statsf[j]);
+				}
+				continue;
+			}
+			if (SV_QCStatKind(j) == QCSTAT_KIND_STRING)
+			{
+				MSG_WriteByte(&buf, svcfte_updatestatstring);
+				MSG_WriteByte(&buf, j);
+				MSG_WriteString(&buf, (char *)(statss[j] ? statss[j] : ""));
+				continue;
+			}
+#endif
+			if (statsi[j] >= 0 && statsi[j] <= 255)
 			{
 				MSG_WriteByte(&buf, svc_updatestat);
 				MSG_WriteByte(&buf, j);
-				MSG_WriteByte(&buf, stats[j]);
+				MSG_WriteByte(&buf, statsi[j]);
 			}
 			else
 			{
 				MSG_WriteByte(&buf, svc_updatestatlong);
 				MSG_WriteByte(&buf, j);
-				MSG_WriteLong(&buf, stats[j]);
+				MSG_WriteLong(&buf, statsi[j]);
 			}
 		}
 

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -914,6 +914,28 @@ static void SV_AddLastDemo(void)
 
 /*
 ====================
+SV_MVD_FreeRecorderCSQC
+
+Frees the recorder's CSQC delta state (pendingcsqcbits) without touching
+demo.dest - used by SV_MVDStop when the recorder really goes away and by
+SV_MVD_Record before it partial-memsets the demo struct on a fresh start.
+====================
+*/
+static void SV_MVD_FreeRecorderCSQC (void)
+{
+#ifdef FTE_PEXT_CSQC
+	if (demo.recorder.pendingcsqcbits)
+	{
+		Q_free(demo.recorder.pendingcsqcbits);
+		demo.recorder.pendingcsqcbits = NULL;
+	}
+	demo.recorder.max_net_ents = 0;
+	demo.recorder.csqcactive = false;
+#endif
+}
+
+/*
+====================
 SV_MVDStop
 
 stop recording a demo
@@ -1003,17 +1025,17 @@ void SV_MVDStop (int reason, qbool mvdonly)
 	instop = false; // SET TO FALSE
 
 out:
-#ifdef FTE_PEXT_CSQC
-	// the recorder struct is memset on the next fresh record start, so free
-	// the CSQC delta bitset here to avoid leaking it
-	if (demo.recorder.pendingcsqcbits)
-	{
-		Q_free(demo.recorder.pendingcsqcbits);
-		demo.recorder.pendingcsqcbits = NULL;
-	}
-	demo.recorder.max_net_ents = 0;
-	demo.recorder.csqcactive = false;
-#endif
+	// Free the recorder's CSQC delta state only when the recorder is really
+	// gone. A mvdonly stop (reason 0/2 via SV_MVDStop_f / SV_MVD_Cancel_f, and
+	// KTX's localcmd("stop")) keeps DEST_STREAM (QTV) destinations alive, so
+	// sv.mvdrecording stays true and the stream still needs csqcactive +
+	// pendingcsqcbits to keep emitting CSQC entities. Clearing them here left
+	// a live QTV stream without CSQC (entities fell back to packetentities and
+	// viewers kept stale state) with no way to re-arm, since
+	// SV_MVD_SendInitialGamestate is only called from SV_MVD_Record (PR228
+	// rev [7]). On the next fresh record start the struct is memset anyway.
+	if (!sv.mvdrecording)
+		SV_MVD_FreeRecorderCSQC();
 	if (reason != 3)
 		SV_BroadcastPrintCache();
 }
@@ -1159,6 +1181,14 @@ qbool SV_MVD_Record (mvddest_t *dest, qbool mapchange)
 	{
 		// this is either mapchange and we have QTV connected
 		// or we just use /record or whatever command first time and here no recording yet
+
+		// The recorder (demo.recorder, holding the CSQC delta bitset) lives
+		// before mem_set_point, so the partial memset below would overwrite
+		// demo.recorder.pendingcsqcbits without freeing it. The ordinary map
+		// path frees it earlier via SV_MVDStop_f, but the savegame `load` path
+		// calls SV_SpawnServer directly (sv_save.c) without it, so free here to
+		// avoid a leak per load (PR228 rev [7], sv_save.c note).
+		SV_MVD_FreeRecorderCSQC();
 
     	// and here we memset() not whole demo_t struct, but part,
     	// so demo.dest and demo.pendingdest is not overwriten

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -52,6 +52,9 @@ cvar_t	sv_ondemoremove		= {"sv_onDemoRemove",	""};
 cvar_t	sv_demoRegexp		= {"sv_demoRegexp",		"\\.mvd(\\.(gz|bz2|rar|zip))?$"};
 
 cvar_t	sv_silentrecord		= {"sv_silentrecord",   "0"};
+// opt-in: record the CSQC stream (svc 76/83, stats 32..127) into MVD/QTV. Off
+// by default because stock ezQuake/QTV cannot parse it (PR228 rev [1]/[1b]).
+cvar_t	sv_mvd_csqc			= {"sv_mvd_csqc",		"0"};
 
 cvar_t	extralogname		= {"extralogname",		"unset"}; // no sv_ prefix? WTF!
 
@@ -1282,7 +1285,9 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 	demo.recorder.fteprotocolextensions |= FTE_PEXT_COLOURMOD;
 #endif
 #ifdef FTE_PEXT_CSQC
-	if (SV_CSQCActive())
+	// Only arm the recorder for CSQC when explicitly opted in: by default the
+	// MVD/QTV stream must stay parseable by stock ezQuake/QTV (PR228 rev [1b]).
+	if (SV_CSQCActive() && (int)sv_mvd_csqc.value)
 	{
 		demo.recorder.fteprotocolextensions |= FTE_PEXT_CSQC;
 		demo.recorder.csqcactive = true;
@@ -1916,6 +1921,7 @@ static void MVD_Init (void)
 	Cvar_Register (&sv_demoExtraNames);
 	Cvar_Register (&sv_demoRegexp);
 	Cvar_Register (&sv_silentrecord);
+	Cvar_Register (&sv_mvd_csqc);
 
 	Cvar_Register (&extralogname);
 

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1254,6 +1254,21 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 	demo.pingtime = demo.time = sv.time;
 	singledest = dest;
 
+#ifdef FTE_PEXT_CSQC
+	// A new dest joins mid-stream (QTV attach) or the map changed: the recorder
+	// shares its CSQC delta bitset across all dests, so re-arm the PRESENT
+	// entities for a full resend, otherwise the joining dest never receives the
+	// CSQC entities it missed (FTE parity, sv_mvd.c:1708). No-op unless the
+	// recorder was explicitly armed for CSQC (sv_mvd_csqc).
+	if (demo.recorder.csqcactive && demo.recorder.pendingcsqcbits)
+	{
+		int e;
+		for (e = 1; e < demo.recorder.max_net_ents; e++)
+			if (demo.recorder.pendingcsqcbits[e] & SENDFLAGS_PRESENT)
+				demo.recorder.pendingcsqcbits[e] |= SENDFLAGS_USABLE;
+	}
+#endif
+
 	/*-------------------------------------------------*/
 
 	// serverdata

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -53,7 +53,7 @@ cvar_t	sv_demoRegexp		= {"sv_demoRegexp",		"\\.mvd(\\.(gz|bz2|rar|zip))?$"};
 
 cvar_t	sv_silentrecord		= {"sv_silentrecord",   "0"};
 // opt-in: record the CSQC stream (svc 76/83, stats 32..127) into MVD/QTV. Off
-// by default because stock ezQuake/QTV cannot parse it (PR228 rev [1]/[1b]).
+// by default because stock ezQuake/QTV cannot parse it.
 cvar_t	sv_mvd_csqc			= {"sv_mvd_csqc",		"0"};
 
 cvar_t	extralogname		= {"extralogname",		"unset"}; // no sv_ prefix? WTF!
@@ -935,7 +935,7 @@ static void SV_MVD_FreeRecorderCSQC (void)
 	}
 	demo.recorder.max_net_ents = 0;
 	demo.recorder.csqcactive = false;
-	// free the recorder's cached string stats (host copies, PR228 [18])
+	// free the recorder's cached string stats (host copies)
 	for (i = 0; i < MAX_CLIENTS; i++)
 		for (j = 0; j < MAX_CL_STATS; j++)
 			Q_free(demo.statss[i][j]);
@@ -1040,8 +1040,8 @@ out:
 	// pendingcsqcbits to keep emitting CSQC entities. Clearing them here left
 	// a live QTV stream without CSQC (entities fell back to packetentities and
 	// viewers kept stale state) with no way to re-arm, since
-	// SV_MVD_SendInitialGamestate is only called from SV_MVD_Record (PR228
-	// rev [7]). On the next fresh record start the struct is memset anyway.
+	// SV_MVD_SendInitialGamestate is only called from SV_MVD_Record. On the
+	// next fresh record start the struct is memset anyway.
 	if (!sv.mvdrecording)
 		SV_MVD_FreeRecorderCSQC();
 	if (reason != 3)
@@ -1195,7 +1195,7 @@ qbool SV_MVD_Record (mvddest_t *dest, qbool mapchange)
 		// demo.recorder.pendingcsqcbits without freeing it. The ordinary map
 		// path frees it earlier via SV_MVDStop_f, but the savegame `load` path
 		// calls SV_SpawnServer directly (sv_save.c) without it, so free here to
-		// avoid a leak per load (PR228 rev [7], sv_save.c note).
+		// avoid a leak per load (see sv_save.c).
 		SV_MVD_FreeRecorderCSQC();
 
     	// and here we memset() not whole demo_t struct, but part,
@@ -1306,7 +1306,7 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 #endif
 #ifdef FTE_PEXT_CSQC
 	// Only arm the recorder for CSQC when explicitly opted in: by default the
-	// MVD/QTV stream must stay parseable by stock ezQuake/QTV (PR228 rev [1b]).
+	// MVD/QTV stream must stay parseable by stock ezQuake/QTV.
 	if (SV_CSQCActive() && (int)sv_mvd_csqc.value)
 	{
 		demo.recorder.fteprotocolextensions |= FTE_PEXT_CSQC;
@@ -1730,7 +1730,7 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 			SV_UpdateQCStats (ent, statsi, statsf, statss);
 #endif
 
-		// legacy 32 stats unless the recorder is explicitly CSQC (PR228 rev [1])
+		// legacy 32 stats unless the recorder is explicitly CSQC
 #ifdef FTE_PEXT_CSQC
 		n = SV_WantsQCStats (&demo.recorder) ? MAX_CL_STATS : MAX_WIRE_STATS;
 #else
@@ -1740,7 +1740,7 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 		for (j = 0; j < n; j++)
 		{
 #ifdef FTE_PEXT_CSQC
-			// PR228 rev [18]: float/string stats use their own wire opcodes
+			// float/string stats use their own wire opcodes
 			if (SV_QCStatKind(j) == QCSTAT_KIND_FLOAT)
 			{
 				if (statsf[j] && statsf[j] != (float)(int)statsf[j])

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1691,10 +1691,8 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 		stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 
 #ifdef FTE_PEXT_CSQC
-		// clientstat/pointerstat registered stats (32..127) - only for the
-		// MVD recorder, which has FTE_PEXT_CSQC set while recording.
-		// TODO (F13): same csqcactive-vs-ext gate question as SV_UpdateClientStats.
-		if (demo.recorder.fteprotocolextensions & FTE_PEXT_CSQC)
+		// clientstat/pointerstat registered stats (32..127) for the recorder.
+		if (SV_WantsQCStats (&demo.recorder))
 			SV_UpdateQCStats (ent, stats);
 #endif
 

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -1325,8 +1325,10 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 	SV_EmitPacketEntities (client, pack, msg);
 
 #ifdef FTE_PEXT_CSQC
-	// CSQC entity lump (delta-compressed), after the regular packetentities
-	SV_EmitCSQCUpdate (client, msg, svc_fte_csqcentities);
+	// CSQC entity lump (delta-compressed), after the regular packetentities.
+	// The sized (92) variant is only for live CSQC clients under sv_csqcdebug;
+	// recorded demos keep the plain (76) form so they play back elsewhere (F6).
+	SV_EmitCSQCUpdate (client, msg, (recorder || !(int)sv_csqcdebug.value) ? svc_fte_csqcentities : svc_fte_csqcentities_sized);
 #endif
 
 	// now add the specialized nail update

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -657,7 +657,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 		{
 			pr_global_struct->self = EDICT_TO_PROG(ent);
 			pr_global_struct->other = viewerent;
-			mod_result = PR2_SendEntity (ent, client->edict, (int)(bits >> SENDFLAGS_SHIFT));
+			mod_result = PR2_SendEntity (ent, client->edict, (uint64_t)(bits >> SENDFLAGS_SHIFT));
 		}
 		else
 #endif

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -755,9 +755,12 @@ void SV_ProcessSendFlags (client_t *c)
 		ent = EDICT_NUM(e);
 		if (ent->e.free)
 			continue;
-		if (ent->xv.sendflags)
+		if (ent->xv.sendflags[0] || ent->xv.sendflags[1] || ent->xv.sendflags[2])
 		{
-			c->pendingcsqcbits[e] |= (uint64_t)ent->xv.sendflags << SENDFLAGS_SHIFT;
+			// pack the 3 float components into the 24-bit fields of pendingcsqcbits
+			c->pendingcsqcbits[e] |= ((uint64_t)((int)ent->xv.sendflags[0] & 0xffffff)
+				| ((uint64_t)((int)ent->xv.sendflags[1] & 0xffffff) << 24)
+				| ((uint64_t)((int)ent->xv.sendflags[2] & 0xffffff) << 48)) << SENDFLAGS_SHIFT;
 			h = e;
 		}
 	}
@@ -787,7 +790,9 @@ void SV_CleanupEnts (void)
 	for (e = 1; e <= needcleanup; e++)
 	{
 		ent = EDICT_NUM(e);
-		ent->xv.sendflags = 0;
+		ent->xv.sendflags[0] = 0;
+		ent->xv.sendflags[1] = 0;
+		ent->xv.sendflags[2] = 0;
 	}
 	needcleanup = 0;
 }

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -1121,7 +1121,7 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 {
 #ifdef FTE_PEXT_CSQC
 	// lazily allocate the per-client CSQC delta bitset
-	if (!client->pendingcsqcbits && sv.max_edicts > 0)
+	if (SV_CSQCActive() && !client->pendingcsqcbits && sv.max_edicts > 0)
 	{
 		client->pendingcsqcbits = Q_calloc(sv.max_edicts, sizeof(uint64_t));
 		client->max_net_ents = sv.max_edicts;

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -602,9 +602,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 	else
 		viewerent = 0; /*for mvds, its as if world is looking*/
 
-	csqcmsgbuffer.data = messagebuffer;
-	csqcmsgbuffer.maxsize = sizeof(messagebuffer);
-	csqcmsgbuffer.cursize = 0;
+	SZ_InitEx (&csqcmsgbuffer, messagebuffer, sizeof(messagebuffer), true);
 
 	for (e = 1; e < sv.num_edicts && e < client->max_net_ents; e++)
 	{
@@ -673,6 +671,13 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 			PR_ExecuteProgram (ent->xv.sendentity);
 			mod_result = G_INT(OFS_RETURN);
 			pr_global_struct->self = old_self;
+		}
+
+		if (csqcmsgbuffer.overflowed)
+		{	// payload too big for the scratch buffer: drop it and retry next frame
+			csqcmsgbuffer.overflowed = false;
+			client->pendingcsqcbits[e] = bits;
+			continue;
 		}
 
 		if (mod_result)	//0 means not to tell the client about it

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -32,6 +32,10 @@ static edict_t *nails[MAX_NAILS];
 static int numnails;
 static int nailcount = 0;
 
+#ifdef FTE_PEXT_CSQC
+sizebuf_t csqcmsgbuffer;	// CSQC entity payload scratch buffer (per SendEntity call)
+#endif
+
 extern	int sv_nailmodel, sv_supernailmodel, sv_playermodel;
 
 cvar_t	sv_nailhack	= {"sv_nailhack", "1"};
@@ -537,6 +541,253 @@ qbool SV_PlayerVisibleToClient (client_t* client, int j, byte* pvs, edict_t* sel
 	return true;
 }
 
+#ifdef FTE_PEXT_CSQC
+/*
+=============
+SV_AddCSQCUpdate
+
+Returns true if the entity is handled by the CSQC system and
+should not be sent via the regular packetentities path.
+=============
+*/
+static qbool SV_AddCSQCUpdate (client_t *client, edict_t *ent)
+{
+	if (!ent->xv.sendentity)
+		return false;
+
+	if (!client->csqcactive)
+		return false;
+
+	return true;
+}
+
+/*
+=============
+SV_EmitDeltaEntIndex
+
+Writes a single entity index for the CSQC lump. 0x8000 flags a remove.
+No big-entity variant: max_net_ents <= 2048 < 0x8000 (no PEXT2_REPLACEMENTDELTAS).
+=============
+*/
+static void SV_EmitDeltaEntIndex (sizebuf_t *msg, unsigned int entnum, qbool remove)
+{
+	unsigned int rflag = remove ? 0x8000 : 0;
+	MSG_WriteShort (msg, entnum | rflag);
+}
+
+/*
+=============
+SV_EmitCSQCUpdate
+
+Writes the svc_fte_csqcentities lump (delta compressed against the
+persistent per-client pendingcsqcbits[]).
+=============
+*/
+static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
+{
+	byte messagebuffer[MAX_DATAGRAM];
+	int e;
+	int viewerent;
+	edict_t *ent;
+	qbool writtenheader = false;
+	uint64_t bits;
+
+	//we don't check that we got some already - because this is delta compressed!
+
+	if (!client->csqcactive || !client->pendingcsqcbits)
+		return;
+
+	if (client->edict)
+		viewerent = EDICT_TO_PROG(client->edict);
+	else
+		viewerent = 0; /*for mvds, its as if world is looking*/
+
+	csqcmsgbuffer.data = messagebuffer;
+	csqcmsgbuffer.maxsize = sizeof(messagebuffer);
+	csqcmsgbuffer.cursize = 0;
+
+	for (e = 1; e < sv.num_edicts && e < client->max_net_ents; e++)
+	{
+		int mod_result = 0;
+		bits = client->pendingcsqcbits[e];
+		if (!bits)
+			continue;
+
+		ent = EDICT_NUM(e);
+		if (ent->e.free || !ent->xv.sendentity)
+		{	// entity is gone or no longer wants CSQC - remove it from the client
+			if (!(bits & SENDFLAGS_REMOVED))
+			{
+				if (bits & SENDFLAGS_PRESENT)
+				{	// the client has it and it vanished: only honor NOREMOVE on a resend
+					if ((int)ent->xv.pvsflags & PVSF_NOREMOVE)
+						continue;
+				}
+			}
+			if (msg->cursize + 5 >= msg->maxsize)
+				break;	// overflow, try again next frame
+
+			if (!writtenheader)
+			{
+				writtenheader = true;
+				MSG_WriteByte (msg, svcnumber);
+			}
+
+			SV_EmitDeltaEntIndex (msg, e, true);
+			client->pendingcsqcbits[e] = 0;
+			continue;
+		}
+
+		if (bits == SENDFLAGS_PRESENT)
+			continue;	// nothing changed
+
+		if (bits & SENDFLAGS_REMOVED)
+		{	// we lost a remove, but it got readded since. make sure all is resent
+			client->pendingcsqcbits[e] = SENDFLAGS_USABLE;
+		}
+
+		if (!(bits & SENDFLAGS_PRESENT))
+			client->pendingcsqcbits[e] = SENDFLAGS_USABLE;	// new entity, make sure its fully transmitted
+
+		bits = client->pendingcsqcbits[e];
+		client->pendingcsqcbits[e] = 0;
+
+		csqcmsgbuffer.cursize = 0;
+
+#ifdef USE_PR2
+		if (sv_vm)
+		{
+			pr_global_struct->self = EDICT_TO_PROG(ent);
+			pr_global_struct->other = viewerent;
+			mod_result = PR2_SendEntity (ent, client->edict, (int)(bits >> SENDFLAGS_SHIFT));
+		}
+		else
+#endif
+		{
+			int old_self = pr_global_struct->self;
+			pr_global_struct->self = EDICT_TO_PROG(ent);
+			G_INT(OFS_PARM0) = viewerent;
+			G_FLOAT(OFS_PARM1+0) = (int)((bits >> (SENDFLAGS_SHIFT+ 0)) & 0xffffff);
+			G_FLOAT(OFS_PARM1+1) = (int)((bits >> (SENDFLAGS_SHIFT+24)) & 0xffffff);
+			G_FLOAT(OFS_PARM1+2) = (int)((bits >> (SENDFLAGS_SHIFT+48)) & 0xffffff);
+			PR_ExecuteProgram (ent->xv.sendentity);
+			mod_result = G_INT(OFS_RETURN);
+			pr_global_struct->self = old_self;
+		}
+
+		if (mod_result)	//0 means not to tell the client about it
+		{
+			//FIXME: don't overflow MAX_DATAGRAM... unless its too big anyway...
+			if (msg->cursize + csqcmsgbuffer.cursize + 5 >= msg->maxsize)
+			{
+				client->pendingcsqcbits[e] = bits;
+				if (csqcmsgbuffer.cursize < 32)
+					break;
+				continue;	// might be able to fit a different ent in there
+			}
+
+			if (!writtenheader)
+			{
+				writtenheader = true;
+				MSG_WriteByte (msg, svcnumber);
+			}
+			SV_EmitDeltaEntIndex (msg, e, false);
+			if (svcnumber == svc_fte_csqcentities_sized)	// optional extra length prefix
+			{
+				if (!csqcmsgbuffer.cursize)
+					Con_Printf ("Warning: empty csqc packet on entity %i\n", e);
+				MSG_WriteShort (msg, csqcmsgbuffer.cursize);
+			}
+			SZ_Write (msg, csqcmsgbuffer.data, csqcmsgbuffer.cursize);
+
+			client->pendingcsqcbits[e] |= SENDFLAGS_PRESENT;
+		}
+		else if ((bits & SENDFLAGS_PRESENT) && !((int)ent->xv.pvsflags & PVSF_NOREMOVE))
+		{	// don't want to send, but they have it already
+			if (msg->cursize + 5 >= msg->maxsize)
+			{
+				client->pendingcsqcbits[e] = bits;
+				break;
+			}
+
+			if (!writtenheader)
+			{
+				writtenheader = true;
+				MSG_WriteByte (msg, svcnumber);
+			}
+
+			SV_EmitDeltaEntIndex (msg, e, true);
+		}
+	}
+
+	if (writtenheader)
+		MSG_WriteShort (msg, 0);	// a 0 means no more.
+
+	// prevent the qc from trying to use it at inopertune times.
+	csqcmsgbuffer.maxsize = 0;
+	csqcmsgbuffer.data = NULL;
+}
+
+static int needcleanup = 0;
+
+/*
+=============
+SV_ProcessSendFlags
+
+Copies the ent->xv.sendflags bits into every client's pendingcsqcbits.
+=============
+*/
+void SV_ProcessSendFlags (client_t *c)
+{
+	edict_t *ent;
+	unsigned int e, h = 0;
+
+	if (!c->csqcactive || !c->pendingcsqcbits)
+		return;
+
+	for (e = 1; e < sv.num_edicts && e < c->max_net_ents; e++)
+	{
+		ent = EDICT_NUM(e);
+		if (ent->e.free)
+			continue;
+		if (ent->xv.sendflags)
+		{
+			c->pendingcsqcbits[e] |= (uint64_t)ent->xv.sendflags << SENDFLAGS_SHIFT;
+			h = e;
+		}
+	}
+	needcleanup = max(needcleanup, h);
+}
+
+/*
+=============
+SV_CleanupEnts
+
+Clears the sendflags on all entities that were processed this frame.
+=============
+*/
+void SV_CleanupEnts (void)
+{
+	int e;
+	edict_t *ent;
+
+	if (!needcleanup)
+		return;
+	if (needcleanup >= sv.num_edicts)
+	{
+		needcleanup = 0;
+		return;
+	}
+
+	for (e = 1; e <= needcleanup; e++)
+	{
+		ent = EDICT_NUM(e);
+		ent->xv.sendflags = 0;
+	}
+	needcleanup = 0;
+}
+#endif
+
 /*
 =============
 SV_WritePlayersToClient
@@ -616,6 +867,11 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 		{ // Vladis
 			continue;
 		}
+
+#ifdef FTE_PEXT_CSQC
+		if (SV_AddCSQCUpdate(client, ent))
+			continue;
+#endif
 
 		//====================================================
 		// OK, seems we must send info about this player below
@@ -853,6 +1109,14 @@ svc_playerinfo messages
 
 void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 {
+#ifdef FTE_PEXT_CSQC
+	// lazily allocate the per-client CSQC delta bitset
+	if (!client->pendingcsqcbits && sv.max_edicts > 0)
+	{
+		client->pendingcsqcbits = Q_calloc(sv.max_edicts, sizeof(uint64_t));
+		client->max_net_ents = sv.max_edicts;
+	}
+#endif
 	qbool disable_updates; // disables sending entities to the client
 	int e, i, max_packet_entities;
 	packet_entities_t *pack;
@@ -969,6 +1233,11 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 				continue;
 			}
 
+#ifdef FTE_PEXT_CSQC
+			if (SV_AddCSQCUpdate(client, ent))
+				continue;
+#endif
+
 			if (SV_AddNailUpdate (ent))
 				continue; // added to the special update list
 
@@ -1044,6 +1313,11 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 	// last packetentities acknowledged by the client
 
 	SV_EmitPacketEntities (client, pack, msg);
+
+#ifdef FTE_PEXT_CSQC
+	// CSQC entity lump (delta-compressed), after the regular packetentities
+	SV_EmitCSQCUpdate (client, msg, svc_fte_csqcentities);
+#endif
 
 	// now add the specialized nail update
 	SV_EmitNailUpdate (msg, recorder);

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -555,9 +555,8 @@ qbool SV_PlayerVisibleToClient (client_t* client, int j, byte* pvs, edict_t* sel
 // PVS-visible CSQC entities collected during one SV_WriteEntitiesToClient call
 // (ascending by entnum): the players loop appends client edicts, the PVS loop
 // appends the rest. SV_EmitCSQCUpdate walks this list so that only visible
-// entities are sent, a PRESENT entity missing from the list is removed
-// (PR228 rev [5]) and a visible entity without PRESENT is force-resend (late
-// joiner / mid-map record, PR228 rev [4]).
+// entities are sent, a PRESENT entity missing from the list is removed, and a
+// visible entity without PRESENT is force-resend (late joiner / mid-map record).
 static edict_t **csqcent;
 static int csqcnuments;
 static int csqcmaxents;
@@ -776,8 +775,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber, 
 	uint64_t bits;
 	client_frame_t *logframe;
 	// per-entity datagram reservation: header(1) + entindex(2) + trailing 0(2),
-	// plus the 2-byte length prefix only the sized (92) variant writes
-	// (PR228 rev [15b]).
+	// plus the 2-byte length prefix only the sized (92) variant writes.
 	int reserve = (svcnumber == svc_fte_csqcentities_sized) ? 7 : 5;
 	int en, entnum;
 	qbool full = false;
@@ -846,7 +844,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber, 
 
 #ifdef USE_PR2
 		// CSQC requires a PR2 VM (SV_CSQCActive() == sv_vm != NULL), so there
-		// is no legacy PR1 path here (PR228 rev [20]). PR2_SendEntity sets
+		// is no legacy PR1 path here. PR2_SendEntity sets
 		// self/other from its args and restores them, so nothing to do here.
 		mod_result = PR2_SendEntity (ent, client->edict, (uint64_t)(bits >> SENDFLAGS_SHIFT));
 #else
@@ -856,7 +854,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber, 
 		if (csqcmsgbuffer.overflowed)
 		{	// payload too big for the per-entity scratch buffer (MAX_DATAGRAM).
 			// It can never fit the client datagram either, so requeueing the
-			// same bits every frame would spin forever (PR228 rev [14]); drop
+			// same bits every frame would spin forever; drop
 			// this entity's update with one warning and wait for a re-dirt.
 			csqcmsgbuffer.overflowed = false;
 			client->pendingcsqcbits[e] = 0;
@@ -965,7 +963,7 @@ void SV_ProcessSendFlags (client_t *c)
 	{
 		ent = EDICT_NUM(e);
 		if (ent->e.free || !ent->xv.sendentity)
-			continue;	// only entities the CSQC system owns may be flagged (PR228 rev [11a])
+			continue;	// only entities the CSQC system owns may be flagged
 		if (ent->xv.sendflags[0] || ent->xv.sendflags[1] || ent->xv.sendflags[2])
 		{
 			// pack the 3 float components into the 24-bit fields of pendingcsqcbits
@@ -1333,7 +1331,7 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 #ifdef FTE_PEXT_CSQC
 	// lazily allocate the per-client CSQC delta bitset, but only for clients
 	// that actually run CSQC: a PR2 server with plain players must not pay for
-	// it (PR228 rev [9]). SV_EnableClientsCSQC arms it earlier on enablecsqc.
+	// it. SV_EnableClientsCSQC arms it earlier on enablecsqc.
 	if (SV_CSQCActive() && client->csqcactive && !client->pendingcsqcbits && sv.max_edicts > 0)
 	{
 		client->pendingcsqcbits = Q_calloc(sv.max_edicts, sizeof(uint64_t));

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -575,6 +575,94 @@ static void SV_EmitDeltaEntIndex (sizebuf_t *msg, unsigned int entnum, qbool rem
 	MSG_WriteShort (msg, entnum | rflag);
 }
 
+#ifdef FTE_PEXT_CSQC
+// Record one entity update emitted into the current frame's datagram so a
+// lost packet can re-flag it (FTE SV_EmitCSQCUpdate resend[]). Only the
+// entity number is kept; on drop it is re-flagged SENDFLAGS_USABLE (full
+// resend - simple and always correct). Overflow falls back to a full resend
+// of all PRESENT entities on drop (csqc_log_overflow).
+static void SV_CSQC_LogAdd (client_t *client, client_frame_t *frame, int entnum)
+{
+	if (client < svs.clients || client >= svs.clients + MAX_CLIENTS)
+		return;	// MVD recorder has its own frame store; no loss recovery there
+	if (frame->csqc_log_overflow)
+		return;
+	if (frame->csqc_lognum >= CSQC_LOG_MAX)
+	{
+		// too many updates in one frame to track individually: on drop, fall
+		// back to a full resend of every PRESENT entity (SV_CSQC_DroppedPacket).
+		frame->csqc_log_overflow = true;
+		return;
+	}
+	frame->csqc_log[frame->csqc_lognum] = entnum;
+	frame->csqc_lognum++;
+}
+
+/*
+=============
+SV_CSQC_DroppedPacket
+
+A frame that went out under `sequence` was lost (client acked past it).
+Re-flag the entities whose updates were in it so they are sent again.
+Mirrors FTE sv_ents.c:557.
+=============
+*/
+void SV_CSQC_DroppedPacket (client_t *client, int sequence)
+{
+	int i;
+	client_frame_t *frame;
+
+	if (!client->csqcactive || !client->pendingcsqcbits)
+		return;
+
+	frame = &client->frames[sequence & UPDATE_MASK];
+
+	// skip if we never generated that frame, to avoid pulling in stale data
+	if (frame->sequence != sequence)
+		return;
+
+	if (frame->csqc_log_overflow)
+	{
+		// too many tracked updates in that frame: resend everything PRESENT
+		for (i = 1; i < client->max_net_ents; i++)
+			if (client->pendingcsqcbits[i] & SENDFLAGS_PRESENT)
+				client->pendingcsqcbits[i] |= SENDFLAGS_USABLE;
+	}
+	else if (frame->csqc_lognum)
+	{
+		for (i = 0; i < frame->csqc_lognum; i++)
+			if (frame->csqc_log[i] < (unsigned short)client->max_net_ents)
+				client->pendingcsqcbits[frame->csqc_log[i]] |= SENDFLAGS_USABLE;
+		frame->csqc_lognum = 0;	// don't resend the same info twice
+	}
+}
+
+/*
+=============
+SV_AckEntityFrame
+
+The client acknowledged up to `framenum`; any frames between the previously
+acknowledged one and this one were lost. Mirrors FTE sv_ents.c:618.
+=============
+*/
+void SV_AckEntityFrame (client_t *client, int framenum)
+{
+	int frame;
+
+	if (!client->csqcactive)
+		return;
+
+	frame = client->csqc_lastack + 1;
+	if (framenum > client->csqc_lastack)
+		client->csqc_lastack = framenum;
+	if (framenum > frame + UPDATE_BACKUP)
+		framenum = frame + UPDATE_BACKUP;
+
+	for (; frame < framenum; frame++)
+		SV_CSQC_DroppedPacket (client, frame);
+}
+#endif
+
 /*
 =============
 SV_EmitCSQCUpdate
@@ -591,11 +679,27 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 	edict_t *ent;
 	qbool writtenheader = false;
 	uint64_t bits;
+	client_frame_t *logframe;
 
 	//we don't check that we got some already - because this is delta compressed!
 
 	if (!client->csqcactive || !client->pendingcsqcbits)
 		return;
+
+	// the datagram we are building goes out under this client's sequence (see
+	// SV_WriteEntitiesToClient frame = frames[incoming_sequence & UPDATE_MASK]
+	// and the clc_delta handler); log every entity update we actually emit into
+	// that frame so a later NACK can re-flag the lost ones (FTE resend[]).
+	{
+		int seq = client->netchan.incoming_sequence;
+		logframe = &client->frames[seq & UPDATE_MASK];
+		if (logframe->sequence != seq)
+		{	// slot reused by a newer frame (older one is long lost/acked)
+			logframe->sequence = seq;
+			logframe->csqc_lognum = 0;
+			logframe->csqc_log_overflow = false;
+		}
+	}
 
 	if (client->edict)
 		viewerent = EDICT_TO_PROG(client->edict);
@@ -632,6 +736,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 			}
 
 			SV_EmitDeltaEntIndex (msg, e, true);
+			SV_CSQC_LogAdd (client, logframe, e);
 			client->pendingcsqcbits[e] = 0;
 			continue;
 		}
@@ -709,6 +814,10 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 			}
 			SZ_Write (msg, csqcmsgbuffer.data, csqcmsgbuffer.cursize);
 
+			// the entity update went into this frame's datagram: remember what
+			// was sent so a lost packet re-flags exactly these bits.
+			SV_CSQC_LogAdd (client, logframe, e);
+
 			client->pendingcsqcbits[e] |= SENDFLAGS_PRESENT;
 		}
 		else if ((bits & SENDFLAGS_PRESENT) && !((int)ent->xv.pvsflags & PVSF_NOREMOVE))
@@ -726,6 +835,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 			}
 
 			SV_EmitDeltaEntIndex (msg, e, true);
+			SV_CSQC_LogAdd (client, logframe, e);
 		}
 	}
 

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -618,11 +618,12 @@ static void SV_EmitDeltaEntIndex (sizebuf_t *msg, unsigned int entnum, qbool rem
 
 #ifdef FTE_PEXT_CSQC
 // Record one entity update emitted into the current frame's datagram so a
-// lost packet can re-flag it (FTE SV_EmitCSQCUpdate resend[]). Only the
-// entity number is kept; on drop it is re-flagged SENDFLAGS_USABLE (full
-// resend - simple and always correct). Overflow falls back to a full resend
-// of all PRESENT entities on drop (csqc_log_overflow).
-static void SV_CSQC_LogAdd (client_t *client, client_frame_t *frame, int entnum)
+// lost packet can re-flag it (FTE SV_EmitCSQCUpdate resend[]). The entry keeps
+// the entity number plus a remove flag; on drop a remove is re-flagged
+// SENDFLAGS_REMOVED (so the remove is re-sent) and a send SENDFLAGS_USABLE
+// (full resend). Overflow falls back to a full resend of all PRESENT entities
+// on drop (csqc_log_overflow).
+static void SV_CSQC_LogAdd (client_t *client, client_frame_t *frame, int entnum, qbool removed)
 {
 	if (client < svs.clients || client >= svs.clients + MAX_CLIENTS)
 		return;	// MVD recorder has its own frame store; no loss recovery there
@@ -635,7 +636,7 @@ static void SV_CSQC_LogAdd (client_t *client, client_frame_t *frame, int entnum)
 		frame->csqc_log_overflow = true;
 		return;
 	}
-	frame->csqc_log[frame->csqc_lognum] = entnum;
+	frame->csqc_log[frame->csqc_lognum] = entnum | (removed ? CSQC_LOG_REMOVE : 0);
 	frame->csqc_lognum++;
 }
 
@@ -672,8 +673,16 @@ void SV_CSQC_DroppedPacket (client_t *client, int sequence)
 	else if (frame->csqc_lognum)
 	{
 		for (i = 0; i < frame->csqc_lognum; i++)
-			if (frame->csqc_log[i] < (unsigned short)client->max_net_ents)
-				client->pendingcsqcbits[frame->csqc_log[i]] |= SENDFLAGS_USABLE;
+		{
+			int e = frame->csqc_log[i] & ~CSQC_LOG_REMOVE;
+
+			if (e >= client->max_net_ents)
+				continue;
+			if (frame->csqc_log[i] & CSQC_LOG_REMOVE)
+				client->pendingcsqcbits[e] |= SENDFLAGS_REMOVED;	// re-send the remove
+			else
+				client->pendingcsqcbits[e] |= SENDFLAGS_USABLE;	// re-send the update
+		}
 		frame->csqc_lognum = 0;	// don't resend the same info twice
 	}
 }
@@ -744,7 +753,7 @@ static qbool SV_CSQC_EmitRemove (client_t *client, sizebuf_t *msg, int svcnumber
 	}
 
 	SV_EmitDeltaEntIndex (msg, e, true);
-	SV_CSQC_LogAdd (client, logframe, e);
+	SV_CSQC_LogAdd (client, logframe, e, true);
 	client->pendingcsqcbits[e] = 0;
 	return true;
 }
@@ -890,7 +899,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber, 
 
 			// the entity update went into this frame's datagram: remember what
 			// was sent so a lost packet re-flags exactly these bits.
-			SV_CSQC_LogAdd (client, logframe, e);
+			SV_CSQC_LogAdd (client, logframe, e, false);
 
 			client->pendingcsqcbits[e] |= SENDFLAGS_PRESENT;
 		}
@@ -910,7 +919,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber, 
 			}
 
 			SV_EmitDeltaEntIndex (msg, e, true);
-			SV_CSQC_LogAdd (client, logframe, e);
+			SV_CSQC_LogAdd (client, logframe, e, true);
 		}
 	}
 
@@ -955,8 +964,8 @@ void SV_ProcessSendFlags (client_t *c)
 	for (e = 1; e < sv.num_edicts && e < c->max_net_ents; e++)
 	{
 		ent = EDICT_NUM(e);
-		if (ent->e.free)
-			continue;
+		if (ent->e.free || !ent->xv.sendentity)
+			continue;	// only entities the CSQC system owns may be flagged (PR228 rev [11a])
 		if (ent->xv.sendflags[0] || ent->xv.sendflags[1] || ent->xv.sendflags[2])
 		{
 			// pack the 3 float components into the 24-bit fields of pendingcsqcbits

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -535,7 +535,8 @@ qbool SV_PlayerVisibleToClient (client_t* client, int j, byte* pvs, edict_t* sel
 		if (cl->spectator)
 			return false;
 
-		if (pvs && ent->e.num_leafs >= 0) {
+		if (((int)ent->xv.pvsflags & PVSF_MODE_MASK) != PVSF_IGNOREPVS &&
+			pvs && ent->e.num_leafs >= 0) {
 			// ignore if not touching a PV leaf
 			for (i = 0; i < ent->e.num_leafs; i++) {
 				if (pvs[ent->e.leafnums[i] >> 3] & (1 << (ent->e.leafnums[i] & 7))) {
@@ -624,7 +625,7 @@ static void SV_EmitDeltaEntIndex (sizebuf_t *msg, unsigned int entnum, qbool rem
 // on drop (csqc_log_overflow).
 static void SV_CSQC_LogAdd (client_t *client, client_frame_t *frame, int entnum, qbool removed)
 {
-	if (client < svs.clients || client >= svs.clients + MAX_CLIENTS)
+	if (client == &demo.recorder)
 		return;	// MVD recorder has its own frame store; no loss recovery there
 	if (frame->csqc_log_overflow)
 		return;
@@ -665,12 +666,16 @@ void SV_CSQC_DroppedPacket (client_t *client, int sequence)
 	if (frame->csqc_log_overflow)
 	{
 		// too many tracked updates in that frame: resend everything PRESENT
+		if ((int)sv_csqcdebug.value)
+			Con_DPrintf("CSQC-DROP frame %d overflow, resend all PRESENT\n", sequence);
 		for (i = 1; i < client->max_net_ents; i++)
 			if (client->pendingcsqcbits[i] & SENDFLAGS_PRESENT)
 				client->pendingcsqcbits[i] |= SENDFLAGS_USABLE;
 	}
 	else if (frame->csqc_lognum)
 	{
+		if ((int)sv_csqcdebug.value)
+			Con_DPrintf("CSQC-DROP frame %d, re-flag %d entities\n", sequence, frame->csqc_lognum);
 		for (i = 0; i < frame->csqc_lognum; i++)
 		{
 			int e = frame->csqc_log[i] & ~CSQC_LOG_REMOVE;
@@ -785,15 +790,24 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber, 
 	if (!client->csqcactive || !client->pendingcsqcbits)
 		return;
 
-	// the datagram we are building goes out under this client's sequence (see
-	// SV_WriteEntitiesToClient frame = frames[incoming_sequence & UPDATE_MASK]
-	// and the clc_delta handler); log every entity update we actually emit into
-	// that frame so a later NACK can re-flag the lost ones (FTE resend[]).
+	// The datagram we are building is transmitted under the client's next
+	// outgoing sequence (Netchan_Transmit stamps it), and the client acks it as
+	// netchan.incoming_acknowledged - the same numbering. Log every entity
+	// update into frames[outgoing_sequence & UPDATE_MASK] so the ack handler can
+	// re-flag the entities of a datagram that was actually lost. Keying this on
+	// incoming_sequence mis-pairs the log with the ack once the two counters
+	// diverge (e.g. on a bandwidth choke), so the wrong datagram was re-flagged
+	// (FTE keys resend[] on outgoing_sequence).
 	{
-		int seq = client->netchan.incoming_sequence;
+		int seq = client->netchan.outgoing_sequence;
 		logframe = &client->frames[seq & UPDATE_MASK];
 		if (logframe->sequence != seq)
-		{	// slot reused by a newer frame (older one is long lost/acked)
+		{
+			// The slot is being reused for a newer datagram. If it still held
+			// updates from an older frame that was never acked, those are lost:
+			// re-flag them before overwriting (FTE SV_ReplaceEntityFrame).
+			if (logframe->sequence && logframe->csqc_lognum)
+				SV_CSQC_DroppedPacket (client, logframe->sequence);
 			logframe->sequence = seq;
 			logframe->csqc_lognum = 0;
 			logframe->csqc_log_overflow = false;
@@ -867,7 +881,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber, 
 			// diagnostic only: sv_csqcdebug 2 shows the datagram accounting
 			// (cur + payload vs maxsize) that the [15b] reserve guards.
 			if ((int)sv_csqcdebug.value == 2)
-				Con_Printf("CSQC-EMIT e=%d cur=%d payload=%d max=%d reserve=%d\n",
+				Con_DPrintf("CSQC-EMIT e=%d cur=%d payload=%d max=%d reserve=%d\n",
 				           e, msg->cursize, csqcmsgbuffer.cursize, msg->maxsize, reserve);
 			//FIXME: don't overflow MAX_DATAGRAM... unless its too big anyway...
 			if (msg->cursize + csqcmsgbuffer.cursize + reserve >= msg->maxsize)
@@ -985,18 +999,20 @@ Clears the sendflags on all entities that were processed this frame.
 */
 void SV_CleanupEnts (void)
 {
-	int e;
+	int e, last;
 	edict_t *ent;
 
 	if (!needcleanup)
 		return;
-	if (needcleanup >= sv.num_edicts)
-	{
-		needcleanup = 0;
-		return;
-	}
 
-	for (e = 1; e <= needcleanup; e++)
+	// sv.num_edicts may have shrunk since the flags were set, so clamp the
+	// range instead of returning early: skipping the clear entirely would leave
+	// stale sendflags on edict slots that may be reused (spurious resends).
+	last = needcleanup;
+	if (last > sv.num_edicts - 1)
+		last = sv.num_edicts - 1;
+
+	for (e = 1; e <= last; e++)
 	{
 		ent = EDICT_NUM(e);
 		ent->xv.sendflags[0] = 0;
@@ -1295,11 +1311,17 @@ qbool SV_EntityVisibleToClient (client_t* client, int e, byte* pvs)
 			return false;
 	}
 
-	// ignore ents without visible models
-	if (!ent->v->modelindex || !*PR_GetEntityString(ent->v->model))
+	// CSQC entities are exempt from the visible-model test: a SendEntity entity
+	// need not carry a model (beams, trails, HUD data carriers) and FTE sends
+	// it regardless. Everything else without a visible model is skipped.
+	if (!(ent->xv.sendentity && client->csqcactive) &&
+		(!ent->v->modelindex || !*PR_GetEntityString(ent->v->model)))
 		return false;
 
-	if ( pvs && ent->e.num_leafs >= 0 )
+	// PVSF_IGNOREPVS entities are global (scoreboard/HUD/objectives): skip the
+	// PVS leaf test. PVSF_USEPHS is not implemented and falls back to PVS.
+	if (((int)ent->xv.pvsflags & PVSF_MODE_MASK) != PVSF_IGNOREPVS &&
+		pvs && ent->e.num_leafs >= 0 )
 	{
 		int i;
 

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -674,9 +674,13 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 		}
 
 		if (csqcmsgbuffer.overflowed)
-		{	// payload too big for the scratch buffer: drop it and retry next frame
+		{	// payload too big for the per-entity scratch buffer (MAX_DATAGRAM).
+			// It can never fit the client datagram either, so requeueing the
+			// same bits every frame would spin forever (PR228 rev [14]); drop
+			// this entity's update with one warning and wait for a re-dirt.
 			csqcmsgbuffer.overflowed = false;
-			client->pendingcsqcbits[e] = bits;
+			client->pendingcsqcbits[e] = 0;
+			Con_Printf("CSQC: entity %i payload overflowed MSG_CSQC buffer, dropping update\n", e);
 			continue;
 		}
 

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -679,6 +679,10 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 	qbool writtenheader = false;
 	uint64_t bits;
 	client_frame_t *logframe;
+	// per-entity datagram reservation: header(1) + entindex(2) + trailing 0(2),
+	// plus the 2-byte length prefix only the sized (92) variant writes
+	// (PR228 rev [15b]).
+	int reserve = (svcnumber == svc_fte_csqcentities_sized) ? 7 : 5;
 
 	//we don't check that we got some already - because this is delta compressed!
 
@@ -773,8 +777,13 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 
 		if (mod_result)	//0 means not to tell the client about it
 		{
+			// diagnostic only: sv_csqcdebug 2 shows the datagram accounting
+			// (cur + payload vs maxsize) that the [15b] reserve guards.
+			if ((int)sv_csqcdebug.value == 2)
+				Con_Printf("CSQC-EMIT e=%d cur=%d payload=%d max=%d reserve=%d\n",
+				           e, msg->cursize, csqcmsgbuffer.cursize, msg->maxsize, reserve);
 			//FIXME: don't overflow MAX_DATAGRAM... unless its too big anyway...
-			if (msg->cursize + csqcmsgbuffer.cursize + 5 >= msg->maxsize)
+			if (msg->cursize + csqcmsgbuffer.cursize + reserve >= msg->maxsize)
 			{
 				client->pendingcsqcbits[e] = bits;
 				if (csqcmsgbuffer.cursize < 32)
@@ -823,6 +832,9 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 
 	if (writtenheader)
 		MSG_WriteShort (msg, 0);	// a 0 means no more.
+
+	if ((int)sv_csqcdebug.value == 2)
+		Con_Printf("CSQC-EMIT done cur=%d writtenheader=%d\n", msg->cursize, writtenheader);
 
 	// prevent the qc from trying to use it at inopertune times.
 	csqcmsgbuffer.maxsize = 0;
@@ -1216,8 +1228,10 @@ svc_playerinfo messages
 void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 {
 #ifdef FTE_PEXT_CSQC
-	// lazily allocate the per-client CSQC delta bitset
-	if (SV_CSQCActive() && !client->pendingcsqcbits && sv.max_edicts > 0)
+	// lazily allocate the per-client CSQC delta bitset, but only for clients
+	// that actually run CSQC: a PR2 server with plain players must not pay for
+	// it (PR228 rev [9]). SV_EnableClientsCSQC arms it earlier on enablecsqc.
+	if (SV_CSQCActive() && client->csqcactive && !client->pendingcsqcbits && sv.max_edicts > 0)
 	{
 		client->pendingcsqcbits = Q_calloc(sv.max_edicts, sizeof(uint64_t));
 		client->max_net_ents = sv.max_edicts;

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -449,6 +449,9 @@ static int TranslateEffects (edict_t *ent)
 SV_MVD_WritePlayersToClient
 =============
 */
+#ifdef FTE_PEXT_CSQC
+static qbool SV_AddCSQCUpdate (client_t *client, edict_t *ent);
+#endif
 static void SV_MVD_WritePlayersToClient ( void )
 {
 	int j;
@@ -468,6 +471,13 @@ static void SV_MVD_WritePlayersToClient ( void )
 			continue;
 
 		ent = cl->edict;
+
+#ifdef FTE_PEXT_CSQC
+		// keep the recorder's CSQC PVS list complete: players are not visited by
+		// the entities loop (it starts at MAX_CLIENTS+1), so collect them here
+		// to avoid the CSQC remove pass dropping an existing player entity.
+		SV_AddCSQCUpdate (&demo.recorder, ent);
+#endif
 
 		dcl->parsecount = demo.parsecount;
 
@@ -542,6 +552,23 @@ qbool SV_PlayerVisibleToClient (client_t* client, int j, byte* pvs, edict_t* sel
 }
 
 #ifdef FTE_PEXT_CSQC
+// PVS-visible CSQC entities collected during one SV_WriteEntitiesToClient call
+// (ascending by entnum): the players loop appends client edicts, the PVS loop
+// appends the rest. SV_EmitCSQCUpdate walks this list so that only visible
+// entities are sent, a PRESENT entity missing from the list is removed
+// (PR228 rev [5]) and a visible entity without PRESENT is force-resend (late
+// joiner / mid-map record, PR228 rev [4]).
+static edict_t **csqcent;
+static int csqcnuments;
+static int csqcmaxents;
+
+void SV_FreeCSQCList (void)
+{
+	Q_free (csqcent);
+	csqcnuments = 0;
+	csqcmaxents = 0;
+}
+
 /*
 =============
 SV_AddCSQCUpdate
@@ -555,8 +582,22 @@ static qbool SV_AddCSQCUpdate (client_t *client, edict_t *ent)
 	if (!ent->xv.sendentity)
 		return false;
 
+	if (ent->e.free)
+		return false;
+
 	if (!client->csqcactive)
 		return false;
+
+	if (csqcnuments >= csqcmaxents)
+	{	// grow the per-frame list (normally sized to sv.max_edicts)
+		int newmax = csqcnuments + 256;
+		edict_t **grown = realloc (csqcent, (size_t)newmax * sizeof(*csqcent));
+		if (!grown)
+			return false;	// out of memory: fall back to packetentities
+		csqcent = grown;
+		csqcmaxents = newmax;
+	}
+	csqcent[csqcnuments++] = ent;
 
 	return true;
 }
@@ -661,6 +702,52 @@ void SV_AckEntityFrame (client_t *client, int framenum)
 	for (; frame < framenum; frame++)
 		SV_CSQC_DroppedPacket (client, frame);
 }
+
+/*
+=============
+SV_CSQC_EmitRemove
+
+Emits a remove for entity `e` when it has PRESENT|REMOVED pending. Entities
+that were never sent are just cleared (no bogus remove). Returns false when the
+datagram is full (caller must stop and retry next frame).
+=============
+*/
+static qbool SV_CSQC_EmitRemove (client_t *client, sizebuf_t *msg, int svcnumber,
+                                 qbool *writtenheader, client_frame_t *logframe, int e)
+{
+	uint64_t bits;
+
+	if (e >= client->max_net_ents)
+		return true;
+
+	bits = client->pendingcsqcbits[e];
+	if (!(bits & (SENDFLAGS_PRESENT | SENDFLAGS_REMOVED)))
+	{
+		client->pendingcsqcbits[e] = 0;	// never sent - nothing to remove
+		return true;
+	}
+
+	if (!(bits & SENDFLAGS_REMOVED) && e < sv.num_edicts)
+	{
+		edict_t *ent = EDICT_NUM(e);
+		if (!ent->e.free && ((int)ent->xv.pvsflags & PVSF_NOREMOVE))
+			return true;	// client keeps it; only a remove-resend may take it away
+	}
+
+	if (msg->cursize + 5 >= msg->maxsize)
+		return false;	// overflow - retry next frame
+
+	if (!*writtenheader)
+	{
+		*writtenheader = true;
+		MSG_WriteByte (msg, svcnumber);
+	}
+
+	SV_EmitDeltaEntIndex (msg, e, true);
+	SV_CSQC_LogAdd (client, logframe, e);
+	client->pendingcsqcbits[e] = 0;
+	return true;
+}
 #endif
 
 /*
@@ -671,7 +758,7 @@ Writes the svc_fte_csqcentities lump (delta compressed against the
 persistent per-client pendingcsqcbits[]).
 =============
 */
-static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
+static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber, qbool allow_removes)
 {
 	byte messagebuffer[MAX_DATAGRAM];
 	int e;
@@ -683,6 +770,8 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 	// plus the 2-byte length prefix only the sized (92) variant writes
 	// (PR228 rev [15b]).
 	int reserve = (svcnumber == svc_fte_csqcentities_sized) ? 7 : 5;
+	int en, entnum;
+	qbool full = false;
 
 	//we don't check that we got some already - because this is delta compressed!
 
@@ -706,39 +795,30 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 
 	SZ_InitEx (&csqcmsgbuffer, messagebuffer, sizeof(messagebuffer), true);
 
-	for (e = 1; e < sv.num_edicts && e < client->max_net_ents; e++)
+	// Walk the PVS-visible list (ascending entnum). Entities with PRESENT bits
+	// that are not in the list left the PVS (or were freed) and are removed;
+	// visible entities without PRESENT are force-resend (late joiner, [4]).
+	entnum = 1;
+	for (en = 0; en < csqcnuments; en++, entnum++)
 	{
 		int mod_result = 0;
-		bits = client->pendingcsqcbits[e];
-		if (!bits)
-			continue;
+		int ve_num = NUM_FOR_EDICT (csqcent[en]);
 
-		ent = EDICT_NUM(e);
-		if (ent->e.free || !ent->xv.sendentity)
-		{	// entity is gone or no longer wants CSQC - remove it from the client
-			if (!(bits & SENDFLAGS_REMOVED))
+		for (; allow_removes && entnum < ve_num; entnum++)
+		{
+			if (!SV_CSQC_EmitRemove (client, msg, svcnumber, &writtenheader, logframe, entnum))
 			{
-				if (bits & SENDFLAGS_PRESENT)
-				{	// the client has it and it vanished: only honor NOREMOVE on a resend
-					if ((int)ent->xv.pvsflags & PVSF_NOREMOVE)
-						continue;
-				}
+				full = true;
+				break;
 			}
-			if (msg->cursize + 5 >= msg->maxsize)
-				break;	// overflow, try again next frame
-
-			if (!writtenheader)
-			{
-				writtenheader = true;
-				MSG_WriteByte (msg, svcnumber);
-			}
-
-			SV_EmitDeltaEntIndex (msg, e, true);
-			SV_CSQC_LogAdd (client, logframe, e);
-			client->pendingcsqcbits[e] = 0;
-			continue;
 		}
+		if (full)
+			break;
 
+		ent = csqcent[en];
+		e = ve_num;
+
+		bits = client->pendingcsqcbits[e];
 		if (bits == SENDFLAGS_PRESENT)
 			continue;	// nothing changed
 
@@ -787,7 +867,10 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 			{
 				client->pendingcsqcbits[e] = bits;
 				if (csqcmsgbuffer.cursize < 32)
+				{
+					full = true;
 					break;
+				}
 				continue;	// might be able to fit a different ent in there
 			}
 
@@ -816,6 +899,7 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 			if (msg->cursize + 5 >= msg->maxsize)
 			{
 				client->pendingcsqcbits[e] = bits;
+				full = true;
 				break;
 			}
 
@@ -830,11 +914,21 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 		}
 	}
 
+	// entities after the last PVS-visible one left the PVS / were freed
+	if (!full && allow_removes)
+	{
+		for (; entnum < client->max_net_ents && entnum < sv.num_edicts; entnum++)
+			if (!SV_CSQC_EmitRemove (client, msg, svcnumber, &writtenheader, logframe, entnum))
+				break;
+	}
+
 	if (writtenheader)
 		MSG_WriteShort (msg, 0);	// a 0 means no more.
 
 	if ((int)sv_csqcdebug.value == 2)
 		Con_Printf("CSQC-EMIT done cur=%d writtenheader=%d\n", msg->cursize, writtenheader);
+
+	csqcnuments = 0;	// the list is rebuilt for the next client/frame
 
 	// prevent the qc from trying to use it at inopertune times.
 	csqcmsgbuffer.maxsize = 0;
@@ -1236,6 +1330,19 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 		client->pendingcsqcbits = Q_calloc(sv.max_edicts, sizeof(uint64_t));
 		client->max_net_ents = sv.max_edicts;
 	}
+
+	// (re)start this client's PVS-visible CSQC entity list; size it once to the
+	// current map's edict count (freed on shutdown)
+	csqcnuments = 0;
+	if (sv.max_edicts > 0 && csqcmaxents < sv.max_edicts)
+	{
+		edict_t **grown = realloc (csqcent, (size_t)sv.max_edicts * sizeof(*csqcent));
+		if (grown)
+		{
+			csqcent = grown;
+			csqcmaxents = sv.max_edicts;
+		}
+	}
 #endif
 	qbool disable_updates; // disables sending entities to the client
 	int e, i, max_packet_entities;
@@ -1438,7 +1545,9 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 	// CSQC entity lump (delta-compressed), after the regular packetentities.
 	// The sized (92) variant is only for live CSQC clients under sv_csqcdebug;
 	// recorded demos keep the plain (76) form so they play back elsewhere.
-	SV_EmitCSQCUpdate (client, msg, (recorder || !(int)sv_csqcdebug.value) ? svc_fte_csqcentities : svc_fte_csqcentities_sized);
+	// Removes are suppressed during a server-flash (disable_updates) frame,
+	// where the PVS loop below did not collect the full visible set.
+	SV_EmitCSQCUpdate (client, msg, (recorder || !(int)sv_csqcdebug.value) ? svc_fte_csqcentities : svc_fte_csqcentities_sized, !disable_updates);
 #endif
 
 	// now add the specialized nail update

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -675,7 +675,6 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 {
 	byte messagebuffer[MAX_DATAGRAM];
 	int e;
-	int viewerent;
 	edict_t *ent;
 	qbool writtenheader = false;
 	uint64_t bits;
@@ -700,11 +699,6 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 			logframe->csqc_log_overflow = false;
 		}
 	}
-
-	if (client->edict)
-		viewerent = EDICT_TO_PROG(client->edict);
-	else
-		viewerent = 0; /*for mvds, its as if world is looking*/
 
 	SZ_InitEx (&csqcmsgbuffer, messagebuffer, sizeof(messagebuffer), true);
 
@@ -758,25 +752,13 @@ static void SV_EmitCSQCUpdate (client_t *client, sizebuf_t *msg, int svcnumber)
 		csqcmsgbuffer.cursize = 0;
 
 #ifdef USE_PR2
-		if (sv_vm)
-		{
-			pr_global_struct->self = EDICT_TO_PROG(ent);
-			pr_global_struct->other = viewerent;
-			mod_result = PR2_SendEntity (ent, client->edict, (uint64_t)(bits >> SENDFLAGS_SHIFT));
-		}
-		else
+		// CSQC requires a PR2 VM (SV_CSQCActive() == sv_vm != NULL), so there
+		// is no legacy PR1 path here (PR228 rev [20]). PR2_SendEntity sets
+		// self/other from its args and restores them, so nothing to do here.
+		mod_result = PR2_SendEntity (ent, client->edict, (uint64_t)(bits >> SENDFLAGS_SHIFT));
+#else
+		mod_result = 0;
 #endif
-		{
-			int old_self = pr_global_struct->self;
-			pr_global_struct->self = EDICT_TO_PROG(ent);
-			G_INT(OFS_PARM0) = viewerent;
-			G_FLOAT(OFS_PARM1+0) = (int)((bits >> (SENDFLAGS_SHIFT+ 0)) & 0xffffff);
-			G_FLOAT(OFS_PARM1+1) = (int)((bits >> (SENDFLAGS_SHIFT+24)) & 0xffffff);
-			G_FLOAT(OFS_PARM1+2) = (int)((bits >> (SENDFLAGS_SHIFT+48)) & 0xffffff);
-			PR_ExecuteProgram (ent->xv.sendentity);
-			mod_result = G_INT(OFS_RETURN);
-			pr_global_struct->self = old_self;
-		}
 
 		if (csqcmsgbuffer.overflowed)
 		{	// payload too big for the per-entity scratch buffer (MAX_DATAGRAM).
@@ -1441,7 +1423,7 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 #ifdef FTE_PEXT_CSQC
 	// CSQC entity lump (delta-compressed), after the regular packetentities.
 	// The sized (92) variant is only for live CSQC clients under sv_csqcdebug;
-	// recorded demos keep the plain (76) form so they play back elsewhere (F6).
+	// recorded demos keep the plain (76) form so they play back elsewhere.
 	SV_EmitCSQCUpdate (client, msg, (recorder || !(int)sv_csqcdebug.value) ? svc_fte_csqcentities : svc_fte_csqcentities_sized);
 #endif
 

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -207,10 +207,35 @@ static unsigned SV_CheckModel(char *mdl)
 }
 
 #ifdef FTE_PEXT_CSQC
+// CSQC is only meaningful for a PR2 mod (native/QVM). A PR1 classic progs.dat
+// cannot drive CSQC, so with it loaded we must not load/announce csprogs and
+// must not advertise FTE_PEXT_CSQC to clients.
+qbool SV_CSQCActive(void)
+{
+	return sv_vm != NULL;
+}
+
+void SV_UpdateCSQCExtension(void)
+{
+	if (sv_vm)
+		svs.fteprotocolextensions |= FTE_PEXT_CSQC;
+	else
+		svs.fteprotocolextensions &= ~FTE_PEXT_CSQC;
+}
+
 static void SV_LoadCSQC(void)
 {
 	extern cvar_t sv_csqc_progname;
 	int size;
+
+	if (!SV_CSQCActive())
+	{
+		sv.csqcchecksum = 0;
+		Info_SetValueForStarKey(svs.info, "*csprogs", "", MAX_SERVERINFO_STRING);
+		Info_SetValueForStarKey(svs.info, "*csprogssize", "", MAX_SERVERINFO_STRING);
+		Info_SetValueForStarKey(svs.info, "*csprogsname", "", MAX_SERVERINFO_STRING);
+		return;
+	}
 
 	byte *file = FS_LoadTempFile(sv_csqc_progname.string, &size);
 	if (file)
@@ -376,10 +401,6 @@ void SV_SpawnServer(char *mapname, qbool devmap, char* entityfile, qbool loading
 
 	sv.time = 1.0;
 
-#ifdef FTE_PEXT_CSQC
-	SV_LoadCSQC();
-#endif
-
 	// load progs to get entity field count
 	// which determines how big each edict is
 	// and allocate edicts
@@ -388,6 +409,13 @@ void SV_SpawnServer(char *mapname, qbool devmap, char* entityfile, qbool loading
 	PR_InitPatchTables();
 #endif
 	PR_InitProg();
+
+#ifdef FTE_PEXT_CSQC
+	// after progs are loaded we know whether the mod is PR2 (CSQC-capable) or
+	// PR1 (.dat, no CSQC); recompute the advertised extension and csprogs keys.
+	SV_UpdateCSQCExtension();
+	SV_LoadCSQC();
+#endif
 
 	for (i = 0; i < sv.max_edicts; i++)
 	{

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -518,13 +518,11 @@ void SV_SpawnServer(char *mapname, qbool devmap, char* entityfile, qbool loading
 		// frame of the new level (client then dies with "csprogsvers/0.dat
 		// required"). On a PR2 map the client re-arms CSQC itself.
 		//
-		// fteprotocolextensions is only dropped for non-CSQC (PR1) mods: ext is
-		// negotiated once at connect ("do not reset") and is NOT re-sent on a
-		// PR2 map change, so clearing it unconditionally would permanently
-		// disable CSQC for an already-connected PR2 client.
+		// fteprotocolextensions is negotiated once at connect and never
+		// re-sent, so it is left untouched here: dropping FTE_PEXT_CSQC on a
+		// PR1 map would permanently disable CSQC for a client that connected
+		// on PR2, and a PR1 qcrequest is swallowed (not dropped) anyway.
 		svs.clients[i].csqcactive = false;
-		if (!SV_CSQCActive())
-			svs.clients[i].fteprotocolextensions &= ~FTE_PEXT_CSQC;
 		if (svs.clients[i].pendingcsqcbits)
 		{
 			Q_free(svs.clients[i].pendingcsqcbits);

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -510,7 +510,7 @@ void SV_SpawnServer(char *mapname, qbool devmap, char* entityfile, qbool loading
 		svs.clients[i].old_frags = 0;
 
 #ifdef FTE_PEXT_CSQC
-		// PR228 rev [6]/[8]: a new map (and possibly a new mod type) is being
+		// A new map (and possibly a new mod type) is being
 		// spawned. The client's CSQC run state is per-level: csprogs is shut
 		// down by the client on map change and re-armed via enablecsqc only
 		// after it sees a fresh *csprogs. Reset csqcactive/bitset here so a

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -226,9 +226,12 @@ void SV_UpdateCSQCExtension(void)
 static void SV_LoadCSQC(void)
 {
 	extern cvar_t sv_csqc_progname;
+	byte *file;
 	int size;
 
-	if (!SV_CSQCActive())
+	// "no csprogs" state (checksum 0 + empty star keys) covers both the PR1
+	// (no CSQC at all) and the missing-csprogs-file cases; set it in one place.
+	if (!SV_CSQCActive() || !(file = FS_LoadTempFile(sv_csqc_progname.string, &size)))
 	{
 		sv.csqcchecksum = 0;
 		Info_SetValueForStarKey(svs.info, "*csprogs", "", MAX_SERVERINFO_STRING);
@@ -237,8 +240,6 @@ static void SV_LoadCSQC(void)
 		return;
 	}
 
-	byte *file = FS_LoadTempFile(sv_csqc_progname.string, &size);
-	if (file)
 	{
 		char text[64];
 		sv.csqcchecksum = Com_BlockChecksum(file, size);
@@ -247,13 +248,6 @@ static void SV_LoadCSQC(void)
 		sprintf(text, "0x%x", (unsigned int)size);
 		Info_SetValueForStarKey(svs.info, "*csprogssize", text, MAX_SERVERINFO_STRING);
 		Info_SetValueForStarKey(svs.info, "*csprogsname", sv_csqc_progname.string, MAX_SERVERINFO_STRING);
-	}
-	else
-	{
-		sv.csqcchecksum = 0;
-		Info_SetValueForStarKey(svs.info, "*csprogs", "", MAX_SERVERINFO_STRING);
-		Info_SetValueForStarKey(svs.info, "*csprogssize", "", MAX_SERVERINFO_STRING);
-		Info_SetValueForStarKey(svs.info, "*csprogsname", "", MAX_SERVERINFO_STRING);
 	}
 }
 #endif

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -514,6 +514,30 @@ void SV_SpawnServer(char *mapname, qbool devmap, char* entityfile, qbool loading
 		svs.clients[i].edict = ent;
 		//ZOID - make sure we update frags right
 		svs.clients[i].old_frags = 0;
+
+#ifdef FTE_PEXT_CSQC
+		// PR228 rev [6]/[8]: a new map (and possibly a new mod type) is being
+		// spawned. The client's CSQC run state is per-level: csprogs is shut
+		// down by the client on map change and re-armed via enablecsqc only
+		// after it sees a fresh *csprogs. Reset csqcactive/bitset here so a
+		// switch to a PR1 mod does not keep emitting svc 76 into the first
+		// frame of the new level (client then dies with "csprogsvers/0.dat
+		// required"). On a PR2 map the client re-arms CSQC itself.
+		//
+		// fteprotocolextensions is only dropped for non-CSQC (PR1) mods: ext is
+		// negotiated once at connect ("do not reset") and is NOT re-sent on a
+		// PR2 map change, so clearing it unconditionally would permanently
+		// disable CSQC for an already-connected PR2 client.
+		svs.clients[i].csqcactive = false;
+		if (!SV_CSQCActive())
+			svs.clients[i].fteprotocolextensions &= ~FTE_PEXT_CSQC;
+		if (svs.clients[i].pendingcsqcbits)
+		{
+			Q_free(svs.clients[i].pendingcsqcbits);
+			svs.clients[i].pendingcsqcbits = NULL;
+		}
+		svs.clients[i].max_net_ents = 0;
+#endif
 	}
 
 	// fill sv.mapname and sv.modelname with new map name

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -438,6 +438,12 @@ void SV_DropClient(client_t* drop)
 
 #ifdef FTE_PEXT_CSQC
 	drop->csqcactive = false;
+	if (drop->pendingcsqcbits)
+	{
+		Q_free(drop->pendingcsqcbits);
+		drop->pendingcsqcbits = NULL;
+	}
+	drop->max_net_ents = 0;
 #endif
 
 	Info_RemoveAll(&drop->_userinfo_ctx_);

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -207,6 +207,7 @@ cvar_t sv_pext_ezquake_verfortrans = {"pext_ezquake_verfortrans", "7814", CVAR_N
 
 #ifdef FTE_PEXT_CSQC
 cvar_t sv_csqc_progname = { "sv_csqc_progname", "csprogs.dat" };
+cvar_t sv_csqcdebug = { "sv_csqcdebug", "0", CVAR_NONE };
 #endif
 
 qbool sv_error = false;
@@ -3614,6 +3615,7 @@ void SV_InitLocal (void)
 
 #ifdef FTE_PEXT_CSQC
 	Cvar_Register (&sv_csqc_progname);
+	Cvar_Register (&sv_csqcdebug);
 #endif
 
 // QW262 -->

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -3665,9 +3665,8 @@ void SV_InitLocal (void)
 #ifdef FTE_PEXT_COLOURMOD
 	svs.fteprotocolextensions |= FTE_PEXT_COLOURMOD;
 #endif
-#ifdef FTE_PEXT_CSQC
-	svs.fteprotocolextensions |= FTE_PEXT_CSQC;
-#endif
+// FTE_PEXT_CSQC is NOT set here: it is added/removed per map in
+// SV_UpdateCSQCExtension() (sv_init.c) depending on whether a PR2 mod is loaded.
 
 #ifdef FTE_PEXT2_VOICECHAT
 	svs.fteprotocolextensions2 |= FTE_PEXT2_VOICECHAT;

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -264,6 +264,9 @@ void SV_Shutdown (char *finalmsg)
 #endif
 
 	// Shutdown game.
+#ifdef FTE_PEXT_CSQC
+	SV_FreeCSQCList ();
+#endif
 	PR_GameShutDown();
 	PR_UnLoadProgs();
 

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -3307,6 +3307,21 @@ void SV_Frame (double time1)
 	// keep the random time dependent
 	rand ();
 
+#ifdef FTE_PEXT_CSQC
+	// A mod that wrote into sv.multicast but did not call multicast() before its
+	// call returned left the buffer unflushed. Left alone it would be merged into
+	// the next multicast() from any source, possibly delivering a CSQC payload to
+	// non-CSQC clients. Drop it and report (diagnostic: sv_csqcdebug).
+	if (sv.multicast.cursize > 0)
+	{
+		if ((int)sv_csqcdebug.value)
+			Con_DPrintf("CSQC: unflushed multicast (%d bytes) dropped (mod missed multicast())\n",
+			            sv.multicast.cursize);
+		SZ_Clear (&sv.multicast);
+		sv.multicast_csqc = false;
+	}
+#endif
+
 	// decide the simulation time
 	if (!sv.paused)
 	{

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -448,6 +448,11 @@ void SV_DropClient(client_t* drop)
 		drop->pendingcsqcbits = NULL;
 	}
 	drop->max_net_ents = 0;
+	{
+		int si;
+		for (si = 0; si < MAX_CL_STATS; si++)
+			Q_free(drop->statss[si]);	// free cached string stats (PR228 [18])
+	}
 #endif
 
 	Info_RemoveAll(&drop->_userinfo_ctx_);

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -451,7 +451,7 @@ void SV_DropClient(client_t* drop)
 	{
 		int si;
 		for (si = 0; si < MAX_CL_STATS; si++)
-			Q_free(drop->statss[si]);	// free cached string stats (PR228 [18])
+			Q_free(drop->statss[si]);	// free cached string stats
 	}
 #endif
 

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -410,6 +410,10 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 	qbool       reliable;
 	vec3_t      vieworg;
 	qbool       mvd_only = false;
+#ifdef FTE_PEXT_CSQC
+	qbool       csqc_only = false;
+	extern cvar_t sv_csqcdebug;
+#endif
 
 	reliable = false;
 
@@ -442,6 +446,27 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 		SV_Error ("SV_Multicast: bad to:%i", to);
 	}
 
+#ifdef FTE_PEXT_CSQC
+	// svc_fte_cgamepacket (ssqc->csqc) only makes sense for CSQC clients.
+	// Convert to the sized variant under sv_csqcdebug (mirror of FTE net_preparse).
+	if (sv.multicast.cursize > 0 && sv.multicast.data[0] == svc_fte_cgamepacket)
+	{
+		int payload_len = sv.multicast.cursize - 1;
+
+		if ((int)sv_csqcdebug.value && sv.multicast.cursize + 2 <= sv.multicast.maxsize)
+		{
+			// buffer: [83][payload] -> [90][lenlo][lenhi][payload]
+			memmove(sv.multicast.data + 3, sv.multicast.data + 1, payload_len);
+			sv.multicast.data[0] = svc_fte_cgamepacket_sized;
+			sv.multicast.data[1] = payload_len & 0xff;
+			sv.multicast.data[2] = (payload_len >> 8) & 0xff;
+			sv.multicast.cursize += 2;
+		}
+
+		csqc_only = true;
+	}
+#endif
+
 	// send the data to all relevent clients
 	for (j = 0, client = svs.clients; j < MAX_CLIENTS && !mvd_only; j++, client++)
 	{
@@ -451,6 +476,11 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 			continue;
 		if (SV_SkipCommsBotMessage(client))
 			continue;
+#ifdef FTE_PEXT_CSQC
+		// svc_fte_cgamepacket is CSQC-only
+		if (csqc_only && !(client->fteprotocolextensions & FTE_PEXT_CSQC))
+			continue;
+#endif
 
 		if (!mask)
 			goto inrange; // multicast to all

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -834,6 +834,115 @@ Performs a delta update of the stats array.  This should only be performed
 when a reliable message can be delivered this frame.
 =======================
 */
+#ifdef FTE_PEXT_CSQC
+// etype codes passed by mods (FTE convention; mvdsv's own etype_t lacks ev_integer)
+#define CSQC_EV_FLOAT		2
+#define CSQC_EV_VECTOR		3
+#define CSQC_EV_ENTITY		4
+#define CSQC_EV_INTEGER		8
+
+typedef struct
+{
+	int		type;		// CSQC_EV_*
+	int		statnum;	// 32..127
+	int		fieldofs;	// clientstat: offset into entvars (0 if pointerstat)
+	void	*ptr;		// pointerstat: resolved host pointer (NULL if clientstat)
+	qbool	isfield;	// true = clientstat (per-client field), false = pointerstat (global)
+} qcstat_t;
+
+static qcstat_t qcstats[MAX_CL_STATS];
+static unsigned int numqcstats;
+
+static void SV_QCStatEval(int type, int statnum, int fieldofs, void *ptr, qbool isfield)
+{
+	unsigned int i;
+
+	if (statnum < 32 || statnum >= MAX_CL_STATS)
+	{
+		Con_Printf("csqc stat %i out of range (32..%i)\n", statnum, MAX_CL_STATS - 1);
+		return;
+	}
+
+	for (i = 0; i < numqcstats; i++)
+		if (qcstats[i].statnum == statnum)
+			break;
+
+	if (i == numqcstats)
+	{
+		if (i == sizeof(qcstats) / sizeof(qcstats[0]))
+		{
+			Con_Printf("Too many csqc stats specified\n");
+			return;
+		}
+		numqcstats++;
+	}
+
+	qcstats[i].type = type;
+	qcstats[i].statnum = statnum;
+	qcstats[i].fieldofs = fieldofs;
+	qcstats[i].ptr = ptr;
+	qcstats[i].isfield = isfield;
+}
+
+// clientstat: register a per-client stat from a field offset into the mod's entvars
+void SV_QCStatFieldIdx(int type, unsigned int fieldindex, int statnum)
+{
+	SV_QCStatEval(type, statnum, fieldindex, NULL, true);
+}
+
+// pointerstat: register a global stat from a resolved host pointer
+void SV_QCStatPtr(int type, void *ptr, int statnum)
+{
+	SV_QCStatEval(type, statnum, 0, ptr, false);
+}
+
+// globalstat: resolve a global by name. PR2 has no name-based global lookup,
+// so this is a no-op that logs (use pointerstat instead).
+void SV_QCStatGlobal(int type, const char *name, int statnum)
+{
+	Con_Printf("globalstat \"%s\" unsupported on PR2, use pointerstat\n", name);
+}
+
+static void SV_UpdateQCStats(edict_t *ent, int *stats)
+{
+	unsigned int i;
+
+	for (i = 0; i < numqcstats; i++)
+	{
+		eval_t *eval;
+		qcstat_t *q = &qcstats[i];
+
+		if (q->isfield)
+			eval = (eval_t *)((byte *)ent->v + q->fieldofs);
+		else
+			eval = (eval_t *)q->ptr;
+
+		if (!eval)
+			continue;
+
+		switch (q->type)
+		{
+		case CSQC_EV_FLOAT:
+			stats[q->statnum] = (int)eval->_float;
+			break;
+		case CSQC_EV_VECTOR:
+			stats[q->statnum + 0] = (int)eval->vector[0];
+			stats[q->statnum + 1] = (int)eval->vector[1];
+			stats[q->statnum + 2] = (int)eval->vector[2];
+			break;
+		case CSQC_EV_ENTITY:
+			stats[q->statnum] = NUM_FOR_EDICT(PROG_TO_EDICT(eval->edict));
+			break;
+		case CSQC_EV_INTEGER:
+			stats[q->statnum] = eval->_int;
+			break;
+		default:
+			break;
+		}
+	}
+}
+#endif
+
 void SV_UpdateClientStats (client_t *client)
 {
 	edict_t *ent;
@@ -876,6 +985,11 @@ void SV_UpdateClientStats (client_t *client)
 
 	if (ent->v->health > 0 || client->spectator) // viewheight for PF_DEAD & PF_GIB is hardwired
 		stats[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
+
+#ifdef FTE_PEXT_CSQC
+	// clientstat/pointerstat registered stats (32..127)
+	SV_UpdateQCStats (ent, stats);
+#endif
 
 	for (i=0 ; i<MAX_CL_STATS ; i++)
 		if (stats[i] != client->stats[i])

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -1447,7 +1447,8 @@ void MVD_WriteStats(void)
 		stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 
 #ifdef FTE_PEXT_CSQC
-		// clientstat/pointerstat registered stats (32..127), recorder will get FTE_PEXT_CSQC in phase 6
+		// clientstat/pointerstat registered stats (32..127) - only for the
+		// MVD recorder, which has FTE_PEXT_CSQC set while recording
 		if (demo.recorder.fteprotocolextensions & FTE_PEXT_CSQC)
 			SV_UpdateQCStats (ent, stats);
 #endif

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -903,8 +903,7 @@ void SV_QCStatGlobal(int type, const char *name, int statnum)
 	Con_Printf("globalstat \"%s\" unsupported on PR2, use pointerstat\n", name);
 }
 
-static void SV_UpdateQCStats(edict_t *ent, int *stats)
-{
+void SV_UpdateQCStats(edict_t *ent, int *stats){
 	unsigned int i;
 
 	for (i = 0; i < numqcstats; i++)
@@ -987,8 +986,9 @@ void SV_UpdateClientStats (client_t *client)
 		stats[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
 
 #ifdef FTE_PEXT_CSQC
-	// clientstat/pointerstat registered stats (32..127)
-	SV_UpdateQCStats (ent, stats);
+	// clientstat/pointerstat registered stats (32..127), only for CSQC clients
+	if (client->fteprotocolextensions & FTE_PEXT_CSQC)
+		SV_UpdateQCStats (ent, stats);
 #endif
 
 	for (i=0 ; i<MAX_CL_STATS ; i++)
@@ -1411,6 +1411,12 @@ void MVD_WriteStats(void)
 
 		// stuff the sigil bits into the high bits of items for sbar
 		stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
+
+#ifdef FTE_PEXT_CSQC
+		// clientstat/pointerstat registered stats (32..127), recorder will get FTE_PEXT_CSQC in phase 6
+		if (demo.recorder.fteprotocolextensions & FTE_PEXT_CSQC)
+			SV_UpdateQCStats (ent, stats);
+#endif
 
 		for (j = 0 ; j < MAX_CL_STATS; j++)
 		{

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -900,6 +900,12 @@ static void SV_QCStatEval(int type, int statnum, int fieldofs, void *ptr, qbool 
 		return;
 	}
 
+	if (type == CSQC_EV_VECTOR && statnum + 2 >= MAX_CL_STATS)
+	{	// a vector stat occupies 3 consecutive slots (statnum..statnum+2)
+		Con_Printf("csqc vector stat %i needs slots %i..%i (max %i)\n", statnum, statnum, statnum + 2, MAX_CL_STATS - 1);
+		return;
+	}
+
 	for (i = 0; i < numqcstats; i++)
 		if (qcstats[i].statnum == statnum)
 			break;
@@ -940,7 +946,8 @@ void SV_QCStatGlobal(int type, const char *name, int statnum)
 	Con_Printf("globalstat \"%s\" unsupported on PR2, use pointerstat\n", name);
 }
 
-void SV_UpdateQCStats(edict_t *ent, int *stats){
+void SV_UpdateQCStats(edict_t *ent, int *stats)
+{
 	unsigned int i;
 
 	for (i = 0; i < numqcstats; i++)

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -412,7 +412,6 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 	qbool       mvd_only = false;
 #ifdef FTE_PEXT_CSQC
 	qbool       csqc_only = false;
-	extern cvar_t sv_csqcdebug;
 #endif
 
 	reliable = false;

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -905,6 +905,9 @@ void SV_SendClientDatagram (client_t *client, int client_num)
 {
 	byte		buf[MAX_DATAGRAM];
 	sizebuf_t	msg;
+#ifdef FTE_PEXT_CSQC
+	byte		csqcbuf[MAX_DATAGRAM];
+#endif
 	//	packet_t	*pack;
 
 	SZ_InitEx(&msg, buf, sizeof(buf), true);
@@ -922,6 +925,13 @@ void SV_SendClientDatagram (client_t *client, int client_num)
 	*/
 
 	if (!SV_SkipCommsBotMessage(client)) {
+#ifdef FTE_PEXT_CSQC
+		// arm the CSQC payload scratch buffer for SV_EmitCSQCUpdate
+		extern sizebuf_t csqcmsgbuffer;
+		csqcmsgbuffer.data = csqcbuf;
+		csqcmsgbuffer.maxsize = sizeof(csqcbuf);
+		csqcmsgbuffer.cursize = 0;
+#endif
 		// add the client specific data to the datagram
 		SV_WriteClientdataToMessage(client, &msg);
 
@@ -930,6 +940,10 @@ void SV_SendClientDatagram (client_t *client, int client_num)
 		// possibly a nails update
 		SV_WriteEntitiesToClient(client, &msg, false);
 
+#ifdef FTE_PEXT_CSQC
+		csqcmsgbuffer.data = NULL;
+		csqcmsgbuffer.maxsize = 0;
+#endif
 #ifdef FTE_PEXT2_VOICECHAT
 		SV_VoiceSendPacket(client, &msg);
 #endif
@@ -1106,6 +1120,10 @@ void SV_SendClientMessages (void)
 		if (!c->state)
 			continue;
 
+#ifdef FTE_PEXT_CSQC
+		SV_ProcessSendFlags (c);
+#endif
+
 		if (c->drop)
 		{
 			SV_DropClient(c);
@@ -1192,6 +1210,12 @@ void SV_SendClientMessages (void)
 			c->datagram.cursize = 0;
 		}
 	}
+
+#ifdef FTE_PEXT_CSQC
+	if (sv.mvdrecording)
+		SV_ProcessSendFlags (&demo.recorder);
+	SV_CleanupEnts ();
+#endif
 }
 
 static void SV_BotWriteDamage(client_t* c, int i)
@@ -1312,6 +1336,9 @@ void SV_SendDemoMessage(void)
 	client_t	*c;
 	sizebuf_t	msg;
 	byte		msg_buf[MAX_MVD_SIZE]; // data without mvd header
+#ifdef FTE_PEXT_CSQC
+	byte		csqcbuf[MAX_MVD_SIZE]; // CSQC payload scratch for the recorder
+#endif
 
 	float		min_fps;
 	extern		cvar_t sv_demofps, sv_demoIdlefps;
@@ -1366,7 +1393,22 @@ void SV_SendDemoMessage(void)
 	if (!demo.recorder.delta_sequence)
 		demo.recorder.delta_sequence = -1;
 
+#ifdef FTE_PEXT_CSQC
+	{
+		// arm the CSQC payload scratch buffer for the demo recorder
+		extern sizebuf_t csqcmsgbuffer;
+		csqcmsgbuffer.data = csqcbuf;
+		csqcmsgbuffer.maxsize = sizeof(csqcbuf);
+		csqcmsgbuffer.cursize = 0;
+	}
+#endif
+
 	SV_WriteEntitiesToClient (&demo.recorder, &msg, true);
+
+#ifdef FTE_PEXT_CSQC
+	csqcmsgbuffer.data = NULL;
+	csqcmsgbuffer.maxsize = 0;
+#endif
 
 	if (msg.overflowed)
 	{

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -883,6 +883,14 @@ typedef struct
 static qcstat_t qcstats[MAX_CL_STATS];
 static unsigned int numqcstats;
 
+// progs (re)loaded (new map / new mod): drop all registered stats so stale
+// pointerstat pointers into the old VM are never dereferenced and re-registration
+// on the next map does not hit "Too many csqc stats".
+void SV_ClearQCStats(void)
+{
+	numqcstats = 0;
+}
+
 static void SV_QCStatEval(int type, int statnum, int fieldofs, void *ptr, qbool isfield)
 {
 	unsigned int i;

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -1071,10 +1071,7 @@ void SV_SendClientDatagram (client_t *client, int client_num)
 	if (!SV_SkipCommsBotMessage(client)) {
 #ifdef FTE_PEXT_CSQC
 		// arm the CSQC payload scratch buffer for SV_EmitCSQCUpdate
-		extern sizebuf_t csqcmsgbuffer;
-		csqcmsgbuffer.data = csqcbuf;
-		csqcmsgbuffer.maxsize = sizeof(csqcbuf);
-		csqcmsgbuffer.cursize = 0;
+		SZ_InitEx (&csqcmsgbuffer, csqcbuf, sizeof(csqcbuf), true);
 #endif
 		// add the client specific data to the datagram
 		SV_WriteClientdataToMessage(client, &msg);
@@ -1546,10 +1543,7 @@ void SV_SendDemoMessage(void)
 #ifdef FTE_PEXT_CSQC
 	{
 		// arm the CSQC payload scratch buffer for the demo recorder
-		extern sizebuf_t csqcmsgbuffer;
-		csqcmsgbuffer.data = csqcbuf;
-		csqcmsgbuffer.maxsize = sizeof(csqcbuf);
-		csqcmsgbuffer.cursize = 0;
+		SZ_InitEx (&csqcmsgbuffer, csqcbuf, sizeof(csqcbuf), true);
 	}
 #endif
 

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -1095,9 +1095,6 @@ void SV_SendClientDatagram (client_t *client, int client_num)
 {
 	byte		buf[MAX_DATAGRAM];
 	sizebuf_t	msg;
-#ifdef FTE_PEXT_CSQC
-	byte		csqcbuf[MAX_DATAGRAM];
-#endif
 	//	packet_t	*pack;
 
 	SZ_InitEx(&msg, buf, sizeof(buf), true);
@@ -1115,10 +1112,6 @@ void SV_SendClientDatagram (client_t *client, int client_num)
 	*/
 
 	if (!SV_SkipCommsBotMessage(client)) {
-#ifdef FTE_PEXT_CSQC
-		// arm the CSQC payload scratch buffer for SV_EmitCSQCUpdate
-		SZ_InitEx (&csqcmsgbuffer, csqcbuf, sizeof(csqcbuf), true);
-#endif
 		// add the client specific data to the datagram
 		SV_WriteClientdataToMessage(client, &msg);
 
@@ -1127,10 +1120,6 @@ void SV_SendClientDatagram (client_t *client, int client_num)
 		// possibly a nails update
 		SV_WriteEntitiesToClient(client, &msg, false);
 
-#ifdef FTE_PEXT_CSQC
-		csqcmsgbuffer.data = NULL;
-		csqcmsgbuffer.maxsize = 0;
-#endif
 #ifdef FTE_PEXT2_VOICECHAT
 		SV_VoiceSendPacket(client, &msg);
 #endif
@@ -1531,9 +1520,6 @@ void SV_SendDemoMessage(void)
 	client_t	*c;
 	sizebuf_t	msg;
 	byte		msg_buf[MAX_MVD_SIZE]; // data without mvd header
-#ifdef FTE_PEXT_CSQC
-	byte		csqcbuf[MAX_MVD_SIZE]; // CSQC payload scratch for the recorder
-#endif
 
 	float		min_fps;
 	extern		cvar_t sv_demofps, sv_demoIdlefps;
@@ -1588,19 +1574,7 @@ void SV_SendDemoMessage(void)
 	if (!demo.recorder.delta_sequence)
 		demo.recorder.delta_sequence = -1;
 
-#ifdef FTE_PEXT_CSQC
-	{
-		// arm the CSQC payload scratch buffer for the demo recorder
-		SZ_InitEx (&csqcmsgbuffer, csqcbuf, sizeof(csqcbuf), true);
-	}
-#endif
-
 	SV_WriteEntitiesToClient (&demo.recorder, &msg, true);
-
-#ifdef FTE_PEXT_CSQC
-	csqcmsgbuffer.data = NULL;
-	csqcmsgbuffer.maxsize = 0;
-#endif
 
 	if (msg.overflowed)
 	{

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -882,6 +882,23 @@ typedef struct
 static qcstat_t qcstats[MAX_CL_STATS];
 static unsigned int numqcstats;
 
+// byte size of the value the mod reads for a given stat type (used to bound
+// the field offset against the entvars block)
+static int qcstat_type_size(int type)
+{
+	switch (type)
+	{
+	case CSQC_EV_FLOAT:
+	case CSQC_EV_ENTITY:
+	case CSQC_EV_INTEGER:
+		return 4;
+	case CSQC_EV_VECTOR:
+		return 12;
+	default:
+		return -1;
+	}
+}
+
 // progs (re)loaded (new map / new mod): drop all registered stats so stale
 // pointerstat pointers into the old VM are never dereferenced and re-registration
 // on the next map does not hit "Too many csqc stats".
@@ -930,6 +947,18 @@ static void SV_QCStatEval(int type, int statnum, int fieldofs, void *ptr, qbool 
 // clientstat: register a per-client stat from a field offset into the mod's entvars
 void SV_QCStatFieldIdx(int type, unsigned int fieldindex, int statnum)
 {
+	int sz = qcstat_type_size(type);
+
+	// the engine later reads (ent->v + fieldofs) up to sz bytes; make sure the
+	// index stays within one entity's entvars block (pr_edict_size bytes)
+	if (sz < 0 || fieldindex > (unsigned int)pr_edict_size
+		|| (unsigned int)sz > (unsigned int)pr_edict_size - fieldindex)
+	{
+		Con_Printf("csqc clientstat field index %u+%d out of entvars (%d)\n",
+			fieldindex, sz, pr_edict_size);
+		return;
+	}
+
 	SV_QCStatEval(type, statnum, fieldindex, NULL, true);
 }
 

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -1023,7 +1023,10 @@ void SV_UpdateClientStats (client_t *client)
 		stats[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
 
 #ifdef FTE_PEXT_CSQC
-	// clientstat/pointerstat registered stats (32..127), only for CSQC clients
+	// clientstat/pointerstat registered stats (32..127), only for CSQC clients.
+	// TODO (F13): gate decision - csqcactive vs FTE_PEXT_CSQC ext. Kept on the
+	// ext gate by default: a CSQC-capable client that never runs csqc simply
+	// ignores the extra stats, and csqcactive implies the ext anyway.
 	if (client->fteprotocolextensions & FTE_PEXT_CSQC)
 		SV_UpdateQCStats (ent, stats);
 #endif
@@ -1448,7 +1451,8 @@ void MVD_WriteStats(void)
 
 #ifdef FTE_PEXT_CSQC
 		// clientstat/pointerstat registered stats (32..127) - only for the
-		// MVD recorder, which has FTE_PEXT_CSQC set while recording
+		// MVD recorder, which has FTE_PEXT_CSQC set while recording.
+		// TODO (F13): same csqcactive-vs-ext gate question as SV_UpdateClientStats.
 		if (demo.recorder.fteprotocolextensions & FTE_PEXT_CSQC)
 			SV_UpdateQCStats (ent, stats);
 #endif

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -401,7 +401,7 @@ MULTICAST_PVS	send to clients potentially visible from org
 MULTICAST_PHS	send to clients potentially hearable from org
 =================
 */
-void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
+static void SV_MulticastInternal (vec3_t origin, int to, const char *cl_reliable_key, qbool force_csqc)
 {
 	client_t*   client;
 	byte*       mask;
@@ -446,14 +446,21 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 	}
 
 #ifdef FTE_PEXT_CSQC
-	// svc_fte_cgamepacket (ssqc->csqc) only makes sense for CSQC clients.
+	// A CSQC packet (svc_fte_cgamepacket) is the whole multicast when it is the
+	// first byte of the buffer (the byte before any payload is always the svc
+	// code, so this can never false-positive on payload). Detect it here as well
+	// as when the caller forces the CSQC path: this keeps a stray CSQC buffer
+	// from reaching non-CSQC clients even if the write-time routing was bypassed.
 	// We do NOT rewrite sv.multicast in place here: the MVD/hidden paths below
 	// must get the original buffer unchanged (recorded demos keep plain svc 76/
 	// 83 so they play back elsewhere, and a hidden block whose first byte is 83
 	// must not be mangled). The sized (90) conversion is applied only when
 	// copying to a live CSQC client under sv_csqcdebug, mirroring FTE's
 	// per-destination net_preparse.
-	csqc_only = sv.multicast.cursize > 0 && sv.multicast.data[0] == svc_fte_cgamepacket;
+	csqc_only = force_csqc ||
+		(sv.multicast.cursize > 0 && sv.multicast.data[0] == svc_fte_cgamepacket);
+#else
+	(void)force_csqc;
 #endif
 
 	// send the data to all relevent clients
@@ -466,8 +473,10 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 		if (SV_SkipCommsBotMessage(client))
 			continue;
 #ifdef FTE_PEXT_CSQC
-		// svc_fte_cgamepacket is CSQC-only
-		if (csqc_only && !(client->fteprotocolextensions & FTE_PEXT_CSQC))
+		// svc_fte_cgamepacket is CSQC-only: skip a client that did not enable
+		// CSQC (it may have negotiated the ext but never sent enablecsqc, so it
+		// has no csprogs to parse the packet).
+		if (csqc_only && !((client->fteprotocolextensions & FTE_PEXT_CSQC) && client->csqcactive))
 			continue;
 #endif
 
@@ -571,7 +580,31 @@ inrange:
 	}
 
 	SZ_Clear (&sv.multicast);
+#ifdef FTE_PEXT_CSQC
+	sv.multicast_csqc = false;
+#endif
 }
+
+void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
+{
+	SV_MulticastInternal (origin, to, cl_reliable_key, false);
+}
+
+#ifdef FTE_PEXT_CSQC
+/*
+=======================
+SV_CSQCMulticast
+
+Dispatch a mod's CSQC packet (svc_fte_cgamepacket) to clients that negotiated
+FTE_PEXT_CSQC and have CSQC active, plus the MVD recorder when sv_mvd_csqc is
+enabled. Other clients never receive it.
+=======================
+*/
+void SV_CSQCMulticast (vec3_t origin, int to)
+{
+	SV_MulticastInternal (origin, to, NULL, true);
+}
+#endif
 
 void SV_Multicast (vec3_t origin, int to)
 {

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -1152,8 +1152,11 @@ void SV_UpdateClientStats (client_t *client)
 	for (i=0 ; i<MAX_CL_STATS ; i++)
 	{
 #ifdef FTE_PEXT_CSQC
-		// CSQC float/string stats use their own wire opcodes
-		if (qcstat_kind[i] == QCSTAT_KIND_FLOAT)
+		// CSQC float/string stats use their own wire opcodes, and only a
+		// destination that negotiated the extension receives them: qcstat_kind[]
+		// is global, so without this gate a stock (non-CSQC) client of a CSQC
+		// mod would get opcode 78/79 and die with "Illegible server message".
+		if (SV_WantsQCStats(client) && qcstat_kind[i] == QCSTAT_KIND_FLOAT)
 		{
 			if (statsf[i] != client->statsf[i])
 			{
@@ -1182,7 +1185,7 @@ void SV_UpdateClientStats (client_t *client)
 			}
 			continue;
 		}
-		if (qcstat_kind[i] == QCSTAT_KIND_STRING)
+		if (SV_WantsQCStats(client) && qcstat_kind[i] == QCSTAT_KIND_STRING)
 		{
 			const char *s = statss[i] ? statss[i] : "";
 
@@ -1190,7 +1193,10 @@ void SV_UpdateClientStats (client_t *client)
 			{
 				if (client->statss[i])
 					Q_free(client->statss[i]);
-				client->statss[i] = *s ? Q_strdup(s) : NULL;
+				// store an empty string as "" (not NULL): NULL must mean
+				// "never sent", otherwise an empty value would be re-emitted
+				// every frame (the !statss[i] test would stay true).
+				client->statss[i] = Q_strdup(s);
 				ClientReliableWrite_Begin(client, svcfte_updatestatstring, 3 + (int)strlen(s));
 				ClientReliableWrite_Byte(client, i);
 				ClientReliableWrite_String(client, (char *)s);
@@ -1272,6 +1278,12 @@ void SV_SendClientDatagram (client_t *client, int client_num)
 	{
 		Con_Printf ("WARNING: msg overflowed for %s\n", client->name);
 		SZ_Clear (&msg);
+#ifdef FTE_PEXT_CSQC
+		// The CSQC updates logged for this datagram were dropped with it, but
+		// the client still acks the (now empty) packet, so re-flag them here
+		// instead of waiting for an ack that will never report them lost.
+		SV_CSQC_DroppedPacket (client, client->netchan.outgoing_sequence);
+#endif
 	}
 
 	// send the datagram
@@ -1673,7 +1685,8 @@ void MVD_WriteStats(void)
 				{
 					if (demo.statss[i][j])
 						Q_free(demo.statss[i][j]);
-					demo.statss[i][j] = *s ? Q_strdup(s) : NULL;
+					// empty value stored as "" (see SV_UpdateClientStats)
+					demo.statss[i][j] = Q_strdup(s);
 					if (MVDWrite_Begin(dem_stats, i, 3 + (int)strlen(s)))
 					{
 						MVD_MSG_WriteByte(svcfte_updatestatstring);

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -1489,6 +1489,12 @@ void MVD_WriteStats(void)
 	int i, j;
 	edict_t		*ent;
 	int			stats[MAX_CL_STATS];
+	// legacy 32 stats unless the recorder is explicitly CSQC (PR228 rev [1])
+#ifdef FTE_PEXT_CSQC
+	int			n = SV_WantsQCStats (&demo.recorder) ? MAX_CL_STATS : MAX_WIRE_STATS;
+#else
+	int			n = MAX_WIRE_STATS;
+#endif
 
 	for (i = 0, c = svs.clients ; i < MAX_CLIENTS ; i++, c++)
 	{
@@ -1523,7 +1529,7 @@ void MVD_WriteStats(void)
 			SV_UpdateQCStats (ent, stats);
 #endif
 
-		for (j = 0 ; j < MAX_CL_STATS; j++)
+		for (j = 0 ; j < n; j++)
 		{
 			if (stats[j] != demo.stats[i][j])
 			{

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -554,6 +554,12 @@ inrange:
 				MVD_SZ_Write(sv.multicast.data, sv.multicast.cursize);
 			}
 		}
+#ifdef FTE_PEXT_CSQC
+		else if (csqc_only && !SV_WantsQCStats(&demo.recorder)) {
+			// CSQC-only message to a stock-compatible recorder: keep it out of
+			// the MVD/QTV stream (PR228 rev [1b])
+		}
+#endif
 		else if (reliable) {
 			if (MVDWrite_Begin(dem_all, 0, sv.multicast.cursize)) {
 				MVD_SZ_Write(sv.multicast.data, sv.multicast.cursize);

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -1042,6 +1042,17 @@ void SV_UpdateQCStats(edict_t *ent, int *stats)
 		}
 	}
 }
+
+// Whether a stats destination (a live client or the MVD recorder) wants the
+// clientstat/pointerstat range 32..127 emitted. Live clients: gate on the
+// negotiated FTE_PEXT_CSQC ext - a CSQC-capable client that never runs csqc
+// ignores the extra stats, and csqcactive implies the ext anyway. The
+// recorder uses the same ext gate today (the demo/QTV compatibility question,
+// PR228 rev [1], is handled separately) (PR228 rev [23]).
+qbool SV_WantsQCStats (client_t *client)
+{
+	return (client->fteprotocolextensions & FTE_PEXT_CSQC) != 0;
+}
 #endif
 
 void SV_UpdateClientStats (client_t *client)
@@ -1089,10 +1100,7 @@ void SV_UpdateClientStats (client_t *client)
 
 #ifdef FTE_PEXT_CSQC
 	// clientstat/pointerstat registered stats (32..127), only for CSQC clients.
-	// TODO (F13): gate decision - csqcactive vs FTE_PEXT_CSQC ext. Kept on the
-	// ext gate by default: a CSQC-capable client that never runs csqc simply
-	// ignores the extra stats, and csqcactive implies the ext anyway.
-	if (client->fteprotocolextensions & FTE_PEXT_CSQC)
+	if (SV_WantsQCStats (client))
 		SV_UpdateQCStats (ent, stats);
 #endif
 
@@ -1504,10 +1512,8 @@ void MVD_WriteStats(void)
 		stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 
 #ifdef FTE_PEXT_CSQC
-		// clientstat/pointerstat registered stats (32..127) - only for the
-		// MVD recorder, which has FTE_PEXT_CSQC set while recording.
-		// TODO (F13): same csqcactive-vs-ext gate question as SV_UpdateClientStats.
-		if (demo.recorder.fteprotocolextensions & FTE_PEXT_CSQC)
+		// clientstat/pointerstat registered stats (32..127) for the recorder.
+		if (SV_WantsQCStats (&demo.recorder))
 			SV_UpdateQCStats (ent, stats);
 #endif
 

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -1003,8 +1003,14 @@ void SV_UpdateQCStats(edict_t *ent, int *stats)
 			stats[q->statnum + 2] = (int)eval->vector[2];
 			break;
 		case CSQC_EV_ENTITY:
-			stats[q->statnum] = NUM_FOR_EDICT(PROG_TO_EDICT(eval->edict));
-			break;
+			{
+				// the field value is mod data and may be out of range or hold a
+				// non-entity float; never let it index sv.edicts (FTE returns
+				// world for out-of-range values instead of crashing).
+				unsigned int idx = (unsigned int)eval->edict / pr_edict_size;
+				stats[q->statnum] = (idx < (unsigned int)sv.num_edicts) ? (int)idx : 0;
+				break;
+			}
 		case CSQC_EV_INTEGER:
 			stats[q->statnum] = eval->_int;
 			break;

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -882,6 +882,7 @@ when a reliable message can be delivered this frame.
 */
 #ifdef FTE_PEXT_CSQC
 // etype codes passed by mods (FTE convention; mvdsv's own etype_t lacks ev_integer)
+#define CSQC_EV_STRING		1
 #define CSQC_EV_FLOAT		2
 #define CSQC_EV_VECTOR		3
 #define CSQC_EV_ENTITY		4
@@ -896,8 +897,19 @@ typedef struct
 	qbool	isfield;	// true = clientstat (per-client field), false = pointerstat (global)
 } qcstat_t;
 
+// wire kind of a registered statnum (drives the emit opcode): 0 = int (nothing
+// registered), 1 = float, 2 = string. Filled by SV_QCStatEval, cleared with the
+// registrations.
 static qcstat_t qcstats[MAX_CL_STATS];
 static unsigned int numqcstats;
+static signed char qcstat_kind[MAX_CL_STATS];
+
+int SV_QCStatKind (int statnum)
+{
+	if (statnum < 0 || statnum >= MAX_CL_STATS)
+		return QCSTAT_KIND_INT;
+	return qcstat_kind[statnum];
+}
 
 // byte size of the value the mod reads for a given stat type (used to bound
 // the field offset against the entvars block)
@@ -908,6 +920,7 @@ static int qcstat_type_size(int type)
 	case CSQC_EV_FLOAT:
 	case CSQC_EV_ENTITY:
 	case CSQC_EV_INTEGER:
+	case CSQC_EV_STRING:
 		return 4;
 	case CSQC_EV_VECTOR:
 		return 12;
@@ -922,6 +935,7 @@ static int qcstat_type_size(int type)
 void SV_ClearQCStats(void)
 {
 	numqcstats = 0;
+	memset(qcstat_kind, 0, sizeof(qcstat_kind));
 }
 
 static void SV_QCStatEval(int type, int statnum, int fieldofs, void *ptr, qbool isfield)
@@ -959,6 +973,16 @@ static void SV_QCStatEval(int type, int statnum, int fieldofs, void *ptr, qbool 
 	qcstats[i].fieldofs = fieldofs;
 	qcstats[i].ptr = ptr;
 	qcstats[i].isfield = isfield;
+
+	// wire kind drives the emit opcode (a vector occupies 3 float slots)
+	qcstat_kind[statnum] = (type == CSQC_EV_STRING) ? QCSTAT_KIND_STRING
+	                     : (type == CSQC_EV_FLOAT || type == CSQC_EV_VECTOR) ? QCSTAT_KIND_FLOAT
+	                     : QCSTAT_KIND_INT;
+	if (type == CSQC_EV_VECTOR)
+	{
+		qcstat_kind[statnum + 1] = QCSTAT_KIND_FLOAT;
+		qcstat_kind[statnum + 2] = QCSTAT_KIND_FLOAT;
+	}
 }
 
 // clientstat: register a per-client stat from a field offset into the mod's entvars
@@ -992,7 +1016,7 @@ void SV_QCStatGlobal(int type, const char *name, int statnum)
 	Con_Printf("globalstat \"%s\" unsupported on PR2, use pointerstat\n", name);
 }
 
-void SV_UpdateQCStats(edict_t *ent, int *stats)
+void SV_UpdateQCStats(edict_t *ent, int *statsi, float *statsf, const char **statss)
 {
 	unsigned int i;
 
@@ -1024,12 +1048,12 @@ void SV_UpdateQCStats(edict_t *ent, int *stats)
 		switch (q->type)
 		{
 		case CSQC_EV_FLOAT:
-			stats[q->statnum] = (int)eval->_float;
+			statsf[q->statnum] = eval->_float;
 			break;
 		case CSQC_EV_VECTOR:
-			stats[q->statnum + 0] = (int)eval->vector[0];
-			stats[q->statnum + 1] = (int)eval->vector[1];
-			stats[q->statnum + 2] = (int)eval->vector[2];
+			statsf[q->statnum + 0] = eval->vector[0];
+			statsf[q->statnum + 1] = eval->vector[1];
+			statsf[q->statnum + 2] = eval->vector[2];
 			break;
 		case CSQC_EV_ENTITY:
 			{
@@ -1037,11 +1061,19 @@ void SV_UpdateQCStats(edict_t *ent, int *stats)
 				// non-entity float; never let it index sv.edicts (FTE returns
 				// world for out-of-range values instead of crashing).
 				unsigned int idx = (unsigned int)eval->edict / pr_edict_size;
-				stats[q->statnum] = (idx < (unsigned int)sv.num_edicts) ? (int)idx : 0;
+				statsi[q->statnum] = (idx < (unsigned int)sv.num_edicts) ? (int)idx : 0;
 				break;
 			}
 		case CSQC_EV_INTEGER:
-			stats[q->statnum] = eval->_int;
+			statsi[q->statnum] = eval->_int;
+			break;
+		case CSQC_EV_STRING:
+			// a QC string field holds a string_t reference; resolve it (PR2)
+#ifdef USE_PR2
+			statss[q->statnum] = PR2_GetString(eval->string);
+#else
+			statss[q->statnum] = PR_GetEntityString(eval->string);
+#endif
 			break;
 		default:
 			break;
@@ -1064,9 +1096,16 @@ qbool SV_WantsQCStats (client_t *client)
 void SV_UpdateClientStats (client_t *client)
 {
 	edict_t *ent;
-	int stats[MAX_CL_STATS], i;
+	int statsi[MAX_CL_STATS], i;
+#ifdef FTE_PEXT_CSQC
+	float statsf[MAX_CL_STATS];
+	const char *statss[MAX_CL_STATS];
 
-	memset (stats, 0, sizeof(stats));
+	memset (statsf, 0, sizeof(statsf));
+	memset (statss, 0, sizeof(statss));
+#endif
+
+	memset (statsi, 0, sizeof(statsi));
 
 	ent = client->edict;
 
@@ -1086,47 +1125,96 @@ void SV_UpdateClientStats (client_t *client)
 			ent = svs.clients[trackent - 1].edict;
 	}
 
-	stats[STAT_HEALTH] = ent->v->health;
-	stats[STAT_WEAPON] = SV_ModelIndex(PR_GetEntityString(ent->v->weaponmodel));
-	stats[STAT_AMMO] = ent->v->currentammo;
-	stats[STAT_ARMOR] = ent->v->armorvalue;
-	stats[STAT_SHELLS] = ent->v->ammo_shells;
-	stats[STAT_NAILS] = ent->v->ammo_nails;
-	stats[STAT_ROCKETS] = ent->v->ammo_rockets;
-	stats[STAT_CELLS] = ent->v->ammo_cells;
+	statsi[STAT_HEALTH] = ent->v->health;
+	statsi[STAT_WEAPON] = SV_ModelIndex(PR_GetEntityString(ent->v->weaponmodel));
+	statsi[STAT_AMMO] = ent->v->currentammo;
+	statsi[STAT_ARMOR] = ent->v->armorvalue;
+	statsi[STAT_SHELLS] = ent->v->ammo_shells;
+	statsi[STAT_NAILS] = ent->v->ammo_nails;
+	statsi[STAT_ROCKETS] = ent->v->ammo_rockets;
+	statsi[STAT_CELLS] = ent->v->ammo_cells;
 	if (!client->spectator || client->spec_track > 0)
-		stats[STAT_ACTIVEWEAPON] = ent->v->weapon;
+		statsi[STAT_ACTIVEWEAPON] = ent->v->weapon;
 	// stuff the sigil bits into the high bits of items for sbar
-	stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
+	statsi[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 	if (fofs_items2)	// ZQ_ITEMS2 extension
-		stats[STAT_ITEMS] |= (int)EdictFieldFloat(ent, fofs_items2) << 23;
+		statsi[STAT_ITEMS] |= (int)EdictFieldFloat(ent, fofs_items2) << 23;
 
 	if (ent->v->health > 0 || client->spectator) // viewheight for PF_DEAD & PF_GIB is hardwired
-		stats[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
+		statsi[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
 
 #ifdef FTE_PEXT_CSQC
 	// clientstat/pointerstat registered stats (32..127), only for CSQC clients.
 	if (SV_WantsQCStats (client))
-		SV_UpdateQCStats (ent, stats);
+		SV_UpdateQCStats (ent, statsi, statsf, statss);
 #endif
 
 	for (i=0 ; i<MAX_CL_STATS ; i++)
-		if (stats[i] != client->stats[i])
+	{
+#ifdef FTE_PEXT_CSQC
+		// PR228 rev [18]: CSQC float/string stats use their own wire opcodes
+		if (qcstat_kind[i] == QCSTAT_KIND_FLOAT)
 		{
-			client->stats[i] = stats[i];
-			if (stats[i] >=0 && stats[i] <= 255)
+			if (statsf[i] != client->statsf[i])
+			{
+				int iv = (int)statsf[i];
+
+				client->statsf[i] = statsf[i];
+				client->stats[i] = iv;	// keep the int cache in sync
+				if (statsf[i] && statsf[i] != (float)iv)
+				{
+					ClientReliableWrite_Begin(client, svcfte_updatestatfloat, 6);
+					ClientReliableWrite_Byte(client, i);
+					ClientReliableWrite_Float(client, statsf[i]);
+				}
+				else if (iv >= 0 && iv <= 255)
+				{
+					ClientReliableWrite_Begin(client, svc_updatestat, 3);
+					ClientReliableWrite_Byte(client, i);
+					ClientReliableWrite_Byte(client, iv);
+				}
+				else
+				{
+					ClientReliableWrite_Begin(client, svc_updatestatlong, 6);
+					ClientReliableWrite_Byte(client, i);
+					ClientReliableWrite_Long(client, iv);
+				}
+			}
+			continue;
+		}
+		if (qcstat_kind[i] == QCSTAT_KIND_STRING)
+		{
+			const char *s = statss[i] ? statss[i] : "";
+
+			if (!client->statss[i] || strcmp(client->statss[i], s))
+			{
+				if (client->statss[i])
+					Q_free(client->statss[i]);
+				client->statss[i] = *s ? Q_strdup(s) : NULL;
+				ClientReliableWrite_Begin(client, svcfte_updatestatstring, 3 + (int)strlen(s));
+				ClientReliableWrite_Byte(client, i);
+				ClientReliableWrite_String(client, (char *)s);
+			}
+			continue;
+		}
+#endif
+		if (statsi[i] != client->stats[i])
+		{
+			client->stats[i] = statsi[i];
+			if (statsi[i] >=0 && statsi[i] <= 255)
 			{
 				ClientReliableWrite_Begin(client, svc_updatestat, 3);
 				ClientReliableWrite_Byte(client, i);
-				ClientReliableWrite_Byte(client, stats[i]);
+				ClientReliableWrite_Byte(client, statsi[i]);
 			}
 			else
 			{
 				ClientReliableWrite_Begin(client, svc_updatestatlong, 6);
 				ClientReliableWrite_Byte(client, i);
-				ClientReliableWrite_Long(client, stats[i]);
+				ClientReliableWrite_Long(client, statsi[i]);
 			}
 		}
+	}
 }
 
 /*
@@ -1488,9 +1576,11 @@ void MVD_WriteStats(void)
 	client_t	*c;
 	int i, j;
 	edict_t		*ent;
-	int			stats[MAX_CL_STATS];
+	int			statsi[MAX_CL_STATS];
 	// legacy 32 stats unless the recorder is explicitly CSQC (PR228 rev [1])
 #ifdef FTE_PEXT_CSQC
+	float		statsf[MAX_CL_STATS];
+	const char	*statss[MAX_CL_STATS];
 	int			n = SV_WantsQCStats (&demo.recorder) ? MAX_CL_STATS : MAX_WIRE_STATS;
 #else
 	int			n = MAX_WIRE_STATS;
@@ -1505,42 +1595,105 @@ void MVD_WriteStats(void)
 			continue;
 
 		ent = c->edict;
-		memset (stats, 0, sizeof(stats));
+		memset (statsi, 0, sizeof(statsi));
+#ifdef FTE_PEXT_CSQC
+		memset (statsf, 0, sizeof(statsf));
+		memset (statss, 0, sizeof(statss));
+#endif
 
-		stats[STAT_HEALTH] = ent->v->health;
-		stats[STAT_WEAPON] = SV_ModelIndex(PR_GetEntityString(ent->v->weaponmodel));
-		stats[STAT_AMMO] = ent->v->currentammo;
-		stats[STAT_ARMOR] = ent->v->armorvalue;
-		stats[STAT_SHELLS] = ent->v->ammo_shells;
-		stats[STAT_NAILS] = ent->v->ammo_nails;
-		stats[STAT_ROCKETS] = ent->v->ammo_rockets;
-		stats[STAT_CELLS] = ent->v->ammo_cells;
-		stats[STAT_ACTIVEWEAPON] = ent->v->weapon;
+		statsi[STAT_HEALTH] = ent->v->health;
+		statsi[STAT_WEAPON] = SV_ModelIndex(PR_GetEntityString(ent->v->weaponmodel));
+		statsi[STAT_AMMO] = ent->v->currentammo;
+		statsi[STAT_ARMOR] = ent->v->armorvalue;
+		statsi[STAT_SHELLS] = ent->v->ammo_shells;
+		statsi[STAT_NAILS] = ent->v->ammo_nails;
+		statsi[STAT_ROCKETS] = ent->v->ammo_rockets;
+		statsi[STAT_CELLS] = ent->v->ammo_cells;
+		statsi[STAT_ACTIVEWEAPON] = ent->v->weapon;
 
 		if (ent->v->health > 0) // viewheight for PF_DEAD & PF_GIB is hardwired
-			stats[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
+			statsi[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
 
 		// stuff the sigil bits into the high bits of items for sbar
-		stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
+		statsi[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 
 #ifdef FTE_PEXT_CSQC
 		// clientstat/pointerstat registered stats (32..127) for the recorder.
 		if (SV_WantsQCStats (&demo.recorder))
-			SV_UpdateQCStats (ent, stats);
+			SV_UpdateQCStats (ent, statsi, statsf, statss);
 #endif
 
 		for (j = 0 ; j < n; j++)
 		{
-			if (stats[j] != demo.stats[i][j])
+#ifdef FTE_PEXT_CSQC
+			// PR228 rev [18]: float/string stats use their own wire opcodes
+			if (SV_QCStatKind(j) == QCSTAT_KIND_FLOAT)
 			{
-				demo.stats[i][j] = stats[j];
-				if (stats[j] >= 0 && stats[j] <= 255)
+				if (statsf[j] != demo.statsf[i][j])
+				{
+					int iv = (int)statsf[j];
+
+					demo.statsf[i][j] = statsf[j];
+					demo.stats[i][j] = iv;
+					if (statsf[j] && statsf[j] != (float)iv)
+					{
+						if (MVDWrite_Begin(dem_stats, i, 6))
+						{
+							MVD_MSG_WriteByte(svcfte_updatestatfloat);
+							MVD_MSG_WriteByte(j);
+							MVD_MSG_WriteFloat(statsf[j]);
+						}
+					}
+					else if (iv >= 0 && iv <= 255)
+					{
+						if (MVDWrite_Begin(dem_stats, i, 3))
+						{
+							MVD_MSG_WriteByte(svc_updatestat);
+							MVD_MSG_WriteByte(j);
+							MVD_MSG_WriteByte(iv);
+						}
+					}
+					else
+					{
+						if (MVDWrite_Begin(dem_stats, i, 6))
+						{
+							MVD_MSG_WriteByte(svc_updatestatlong);
+							MVD_MSG_WriteByte(j);
+							MVD_MSG_WriteLong(iv);
+						}
+					}
+				}
+				continue;
+			}
+			if (SV_QCStatKind(j) == QCSTAT_KIND_STRING)
+			{
+				const char *s = statss[j] ? statss[j] : "";
+
+				if (!demo.statss[i][j] || strcmp(demo.statss[i][j], s))
+				{
+					if (demo.statss[i][j])
+						Q_free(demo.statss[i][j]);
+					demo.statss[i][j] = *s ? Q_strdup(s) : NULL;
+					if (MVDWrite_Begin(dem_stats, i, 3 + (int)strlen(s)))
+					{
+						MVD_MSG_WriteByte(svcfte_updatestatstring);
+						MVD_MSG_WriteByte(j);
+						MVD_MSG_WriteString(s);
+					}
+				}
+				continue;
+			}
+#endif
+			if (statsi[j] != demo.stats[i][j])
+			{
+				demo.stats[i][j] = statsi[j];
+				if (statsi[j] >= 0 && statsi[j] <= 255)
 				{
 					if (MVDWrite_Begin(dem_stats, i, 3))
 					{
 						MVD_MSG_WriteByte(svc_updatestat);
 						MVD_MSG_WriteByte(j);
-						MVD_MSG_WriteByte(stats[j]);
+						MVD_MSG_WriteByte(statsi[j]);
 					}
 				}
 				else
@@ -1549,7 +1702,7 @@ void MVD_WriteStats(void)
 					{
 						MVD_MSG_WriteByte(svc_updatestatlong);
 						MVD_MSG_WriteByte(j);
-						MVD_MSG_WriteLong(stats[j]);
+						MVD_MSG_WriteLong(statsi[j]);
 					}
 				}
 			}

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -452,7 +452,7 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 	// 83 so they play back elsewhere, and a hidden block whose first byte is 83
 	// must not be mangled). The sized (90) conversion is applied only when
 	// copying to a live CSQC client under sv_csqcdebug, mirroring FTE's
-	// per-destination net_preparse (PR228 rev [15]).
+	// per-destination net_preparse.
 	csqc_only = sv.multicast.cursize > 0 && sv.multicast.data[0] == svc_fte_cgamepacket;
 #endif
 
@@ -557,7 +557,7 @@ inrange:
 #ifdef FTE_PEXT_CSQC
 		else if (csqc_only && !SV_WantsQCStats(&demo.recorder)) {
 			// CSQC-only message to a stock-compatible recorder: keep it out of
-			// the MVD/QTV stream (PR228 rev [1b])
+			// the MVD/QTV stream
 		}
 #endif
 		else if (reliable) {
@@ -993,7 +993,7 @@ void SV_QCStatFieldIdx(int type, unsigned int fieldindex, int statnum)
 	// GAME_INIT, which runs before PR2_InitProg assigns pr_edict_size (so it is 0
 	// on the first map and all registrations would be dropped) and a gamedir
 	// switch can leave a stale larger value. Bound instead at use time in
-	// SV_UpdateQCStats (PR228 rev [10]). Only the value type is checked here.
+	// SV_UpdateQCStats. Only the value type is checked here.
 	if (qcstat_type_size(type) < 0)
 	{
 		Con_Printf("csqc clientstat type %d unsupported\n", type);
@@ -1029,7 +1029,7 @@ void SV_UpdateQCStats(edict_t *ent, int *statsi, float *statsf, const char **sta
 		{
 			int sz = qcstat_type_size(q->type);
 
-			// PR228 rev [10]: bound at use, not at registration - GAME_INIT runs
+			// bound at use, not at registration - GAME_INIT runs
 			// before pr_edict_size is assigned, and a gamedir switch may leave a
 			// stale (larger) value. Skip a field that is no longer within the
 			// current entvars block instead of reading out of bounds.
@@ -1085,8 +1085,8 @@ void SV_UpdateQCStats(edict_t *ent, int *statsi, float *statsf, const char **sta
 // clientstat/pointerstat range 32..127 emitted. Live clients: gate on the
 // negotiated FTE_PEXT_CSQC ext - a CSQC-capable client that never runs csqc
 // ignores the extra stats, and csqcactive implies the ext anyway. The
-// recorder uses the same ext gate today (the demo/QTV compatibility question,
-// PR228 rev [1], is handled separately) (PR228 rev [23]).
+// recorder only gets FTE_PEXT_CSQC when sv_mvd_csqc is set (SV_MVD_Record),
+// which is also what keeps stock ezQuake/QTV demos compatible.
 qbool SV_WantsQCStats (client_t *client)
 {
 	return (client->fteprotocolextensions & FTE_PEXT_CSQC) != 0;
@@ -1152,7 +1152,7 @@ void SV_UpdateClientStats (client_t *client)
 	for (i=0 ; i<MAX_CL_STATS ; i++)
 	{
 #ifdef FTE_PEXT_CSQC
-		// PR228 rev [18]: CSQC float/string stats use their own wire opcodes
+		// CSQC float/string stats use their own wire opcodes
 		if (qcstat_kind[i] == QCSTAT_KIND_FLOAT)
 		{
 			if (statsf[i] != client->statsf[i])
@@ -1577,7 +1577,7 @@ void MVD_WriteStats(void)
 	int i, j;
 	edict_t		*ent;
 	int			statsi[MAX_CL_STATS];
-	// legacy 32 stats unless the recorder is explicitly CSQC (PR228 rev [1])
+	// legacy 32 stats unless the recorder is explicitly CSQC
 #ifdef FTE_PEXT_CSQC
 	float		statsf[MAX_CL_STATS];
 	const char	*statss[MAX_CL_STATS];
@@ -1626,7 +1626,7 @@ void MVD_WriteStats(void)
 		for (j = 0 ; j < n; j++)
 		{
 #ifdef FTE_PEXT_CSQC
-			// PR228 rev [18]: float/string stats use their own wire opcodes
+			// float/string stats use their own wire opcodes
 			if (SV_QCStatKind(j) == QCSTAT_KIND_FLOAT)
 			{
 				if (statsf[j] != demo.statsf[i][j])

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -947,15 +947,15 @@ static void SV_QCStatEval(int type, int statnum, int fieldofs, void *ptr, qbool 
 // clientstat: register a per-client stat from a field offset into the mod's entvars
 void SV_QCStatFieldIdx(int type, unsigned int fieldindex, int statnum)
 {
-	int sz = qcstat_type_size(type);
-
-	// the engine later reads (ent->v + fieldofs) up to sz bytes; make sure the
-	// index stays within one entity's entvars block (pr_edict_size bytes)
-	if (sz < 0 || fieldindex > (unsigned int)pr_edict_size
-		|| (unsigned int)sz > (unsigned int)pr_edict_size - fieldindex)
+	// The engine later reads (ent->v + fieldofs) up to sz bytes. The offset is
+	// NOT validated against pr_edict_size here: mods register clientstats during
+	// GAME_INIT, which runs before PR2_InitProg assigns pr_edict_size (so it is 0
+	// on the first map and all registrations would be dropped) and a gamedir
+	// switch can leave a stale larger value. Bound instead at use time in
+	// SV_UpdateQCStats (PR228 rev [10]). Only the value type is checked here.
+	if (qcstat_type_size(type) < 0)
 	{
-		Con_Printf("csqc clientstat field index %u+%d out of entvars (%d)\n",
-			fieldindex, sz, pr_edict_size);
+		Con_Printf("csqc clientstat type %d unsupported\n", type);
 		return;
 	}
 
@@ -985,7 +985,19 @@ void SV_UpdateQCStats(edict_t *ent, int *stats)
 		qcstat_t *q = &qcstats[i];
 
 		if (q->isfield)
+		{
+			int sz = qcstat_type_size(q->type);
+
+			// PR228 rev [10]: bound at use, not at registration - GAME_INIT runs
+			// before pr_edict_size is assigned, and a gamedir switch may leave a
+			// stale (larger) value. Skip a field that is no longer within the
+			// current entvars block instead of reading out of bounds.
+			if (sz < 0 || q->fieldofs < 0
+				|| (unsigned int)q->fieldofs + (unsigned int)sz > (unsigned int)pr_edict_size)
+				continue;
+
 			eval = (eval_t *)((byte *)ent->v + q->fieldofs);
+		}
 		else
 			eval = (eval_t *)q->ptr;
 

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -447,23 +447,13 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 
 #ifdef FTE_PEXT_CSQC
 	// svc_fte_cgamepacket (ssqc->csqc) only makes sense for CSQC clients.
-	// Convert to the sized variant under sv_csqcdebug (mirror of FTE net_preparse).
-	if (sv.multicast.cursize > 0 && sv.multicast.data[0] == svc_fte_cgamepacket)
-	{
-		int payload_len = sv.multicast.cursize - 1;
-
-		if ((int)sv_csqcdebug.value && sv.multicast.cursize + 2 <= sv.multicast.maxsize)
-		{
-			// buffer: [83][payload] -> [90][lenlo][lenhi][payload]
-			memmove(sv.multicast.data + 3, sv.multicast.data + 1, payload_len);
-			sv.multicast.data[0] = svc_fte_cgamepacket_sized;
-			sv.multicast.data[1] = payload_len & 0xff;
-			sv.multicast.data[2] = (payload_len >> 8) & 0xff;
-			sv.multicast.cursize += 2;
-		}
-
-		csqc_only = true;
-	}
+	// We do NOT rewrite sv.multicast in place here: the MVD/hidden paths below
+	// must get the original buffer unchanged (recorded demos keep plain svc 76/
+	// 83 so they play back elsewhere, and a hidden block whose first byte is 83
+	// must not be mangled). The sized (90) conversion is applied only when
+	// copying to a live CSQC client under sv_csqcdebug, mirroring FTE's
+	// per-destination net_preparse (PR228 rev [15]).
+	csqc_only = sv.multicast.cursize > 0 && sv.multicast.data[0] == svc_fte_cgamepacket;
 #endif
 
 	// send the data to all relevent clients
@@ -522,13 +512,34 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 		}
 
 inrange:
-		if (reliable || (cl_reliable_key && *cl_reliable_key && strcmp("0", Info_Get(&client->_userinfo_ctx_, cl_reliable_key))))
 		{
-			ClientReliableCheckBlock(client, sv.multicast.cursize);
-			ClientReliableWrite_SZ(client, sv.multicast.data, sv.multicast.cursize);
+			// per-destination view of the payload: normally sv.multicast as-is;
+			// a cgamepacket to a live CSQC client becomes sized under
+			// sv_csqcdebug (MVD/hidden keep the plain form below).
+			byte *data = sv.multicast.data;
+			int   len = sv.multicast.cursize;
+#ifdef FTE_PEXT_CSQC
+			byte  sized[MAX_MSGLEN + 2];
+			if (csqc_only && (int)sv_csqcdebug.value && (client->fteprotocolextensions & FTE_PEXT_CSQC)
+				&& sv.multicast.cursize + 2 <= (int)sizeof(sized))
+			{
+				// [83][payload] -> [90][lenlo][lenhi][payload]
+				sized[0] = svc_fte_cgamepacket_sized;
+				sized[1] = sv.multicast.cursize - 1;
+				sized[2] = (sv.multicast.cursize - 1) >> 8;
+				memcpy(sized + 3, sv.multicast.data + 1, sv.multicast.cursize - 1);
+				data = sized;
+				len = sv.multicast.cursize + 2;
+			}
+#endif
+			if (reliable || (cl_reliable_key && *cl_reliable_key && strcmp("0", Info_Get(&client->_userinfo_ctx_, cl_reliable_key))))
+			{
+				ClientReliableCheckBlock(client, len);
+				ClientReliableWrite_SZ(client, data, len);
+			}
+			else
+				SZ_Write (&client->datagram, data, len);
 		}
-		else
-			SZ_Write (&client->datagram, sv.multicast.data, sv.multicast.cursize);
 	}
 
 	if (sv.mvdrecording) {

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -4488,8 +4488,14 @@ static void SV_DebugServerSideWeaponScript(client_t* cl, int best_impulse)
 #define QCREQ_T_ENTITY	3
 #define QCREQ_T_INT		4
 
-// wire type codes (FTE etype convention; mvdsv's own etype_t lacks ev_integer)
+// wire type codes (FTE etype convention; mvdsv's own etype_t lacks the
+// extended integer/pointer types). Consumed by width so a client using the
+// richer FTE types is not dropped (F9).
 #define QCREQ_EV_INTEGER	8
+#define QCREQ_EV_UINT		9
+#define QCREQ_EV_INT64		10
+#define QCREQ_EV_UINT64		11
+#define QCREQ_EV_DOUBLE		12
 
 /*
 ===================
@@ -4498,14 +4504,23 @@ SV_ReadQCRequest
 Parses a clcfte_qcrequest (client CSQC sendevent) message and dispatches
 to the game: PR2 -> GAME_QCREQUEST export, PR1 -> CSEv_* function.
 
-Wire layout (client->server, matches the client-side writer):
+Wire layout (client->server, matches the FTE csqc writer PF_cs_sendevent):
   for each arg: [byte type] [value]
-    ev_float   -> float
-    ev_vector  -> 3 floats
-    ev_integer -> long
-    ev_entity  -> short (entity number)
-    ev_string  -> string
-  then [string eventname]
+    ev_void     -> end of args
+    ev_float    -> float
+    ev_vector   -> 3 floats
+    ev_integer  -> long
+    ev_uint     -> long (consumed; PR2 has no unsigned slot)
+    ev_int64/ev_uint64/ev_double -> 8 bytes (consumed)
+    ev_entity   -> short (entity number)
+    ev_string   -> string
+    ev_pointer  -> payload whose byte length is the preceding ev_integer value
+    other       -> treated as a long (FTE default), arg marked '?'
+  an optional [200+seat] marker byte may precede the terminator
+  then [0 terminator] then [string eventname]
+Unknown/unsupported arg types are consumed (never msg_badread on the type
+itself) so the client is not kicked; such args are delivered as '?' with no
+argtypes bits set.
 ===================
 */
 static void SV_ReadQCRequest(void)
@@ -4540,6 +4555,9 @@ static void SV_ReadQCRequest(void)
 			return;
 		}
 
+		if (ev >= 200)
+			continue;	// fte split-screen seat marker: ignore (mvdsv has no csqc seats)
+
 		switch (ev)
 		{
 		case ev_void:
@@ -4560,6 +4578,36 @@ static void SV_ReadQCRequest(void)
 			args[i] = 'i';
 			((int *)&PR_GLOBAL(parm1))[i*3 + 0] = MSG_ReadLong();
 			argtypes |= QCREQ_T_INT << (i * 3);
+			break;
+		case QCREQ_EV_UINT:
+			args[i] = 'u';
+			((int *)&PR_GLOBAL(parm1))[i*3 + 0] = MSG_ReadLong();
+			argtypes |= QCREQ_T_INT << (i * 3);
+			break;
+		case QCREQ_EV_INT64:
+		case QCREQ_EV_UINT64:
+		case QCREQ_EV_DOUBLE:
+			args[i] = '?';	// 64-bit/double: no PR2 slot, consume and skip
+			MSG_ReadByte();	// 8 bytes
+			MSG_ReadByte();
+			MSG_ReadByte();
+			MSG_ReadByte();
+			MSG_ReadByte();
+			MSG_ReadByte();
+			MSG_ReadByte();
+			MSG_ReadByte();
+			break;
+		case ev_pointer:
+			args[i] = 'p';
+			// payload length is carried by the preceding ev_integer arg value
+			if (i > 0 && args[i-1] == 'i')
+			{
+				int len = ((int *)&PR_GLOBAL(parm1))[(i-1)*3 + 0];
+				if (len < 0 || len > (1 << 16))
+					break;	// nonsense length: cannot realign, stop parsing args
+				while (len-- > 0)
+					MSG_ReadByte();
+			}
 			break;
 		case ev_entity:
 			{
@@ -4604,8 +4652,11 @@ static void SV_ReadQCRequest(void)
 			}
 			break;
 		default:
-			msg_badread = true;
-			return;
+			// unknown wire type: don't kick the client, consume it as a long
+			// (FTE fallback width) and mark the arg as unsupported
+			args[i] = '?';
+			MSG_ReadLong();
+			break;
 		}
 	}
 

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -4702,9 +4702,21 @@ static void SV_ReadQCRequest(void)
 			{
 				int len = qcrequest_args[i-1].i;
 				if (len < 0 || len > (1 << 16))
-					break;	// nonsense length: cannot realign
+				{
+					// nonsense length: cannot realign - drop the message instead
+					// of continuing the parse misaligned
+					msg_badread = true;
+					return;
+				}
 				while (len-- > 0)
 					MSG_ReadByte();
+			}
+			else
+			{
+				// ev_pointer without a preceding ev_integer length: no way to
+				// know the payload width - drop the message
+				msg_badread = true;
+				return;
 			}
 			break;
 		case ev_entity:

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -3123,6 +3123,9 @@ void SV_EnableClientsCSQC(void)
 {
 	int e;
 
+	if (!SV_CSQCActive())
+		return; // PR1 mod: no CSQC support, ignore the client request
+
 	sv_client->csqcactive = true;
 
 	// the client just (re)enabled csqc: resend all entities it already has
@@ -3135,6 +3138,9 @@ void SV_EnableClientsCSQC(void)
 
 void SV_DisableClientsCSQC(void)
 {
+	if (!SV_CSQCActive())
+		return; // PR1 mod: no CSQC support, ignore the client request
+
 	sv_client->csqcactive = false;
 }
 #endif
@@ -5054,6 +5060,12 @@ void SV_ExecuteClientMessage (client_t *cl)
 
 #ifdef FTE_PEXT_CSQC
 		case clcfte_qcrequest:
+			if (!SV_CSQCActive())
+			{
+				// PR1 mod: CSQC is disabled, ignore the sendevent instead of dropping
+				Con_DPrintf("client %s sent qcrequest but the loaded mod is PR1 (no CSQC)\n", cl->name);
+				break;
+			}
 			if (!(cl->fteprotocolextensions & FTE_PEXT_CSQC))
 			{
 				Con_Printf("client %s sent qcrequest without CSQC extension\n", cl->name);

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -4864,6 +4864,9 @@ void SV_ExecuteClientMessage (client_t *cl)
 			// if the client asks for a delta from an older sequence than the
 			// last one we sent, some packets were lost - flag all CSQC ents
 			// the client already has for a full resend (simplified NACK).
+			// TODO (F8): heuristic is unverified under packet loss - add the
+			// loss scenario from mvdsv_csqc_steps.md Phase 8 and only tune it
+			// against measured results before changing it.
 			if (cl->pendingcsqcbits &&
 				cl->delta_sequence != -1 &&
 				(unsigned int)cl->delta_sequence < (unsigned int)cl->netchan.outgoing_sequence)

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -22,6 +22,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #ifndef CLIENTONLY
 #include "qwsvdef.h"
+#ifdef USE_PR2
+#include "vm_local.h"
+#endif
 
 static void SV_ClientDownloadComplete(client_t* cl);
 
@@ -4477,6 +4480,169 @@ static void SV_DebugServerSideWeaponScript(client_t* cl, int best_impulse)
 }
 #endif
 
+#ifdef FTE_PEXT_CSQC
+// sendevent type codes (design doc ezquake_csqc_pr2.md §5.2); engine and mod must agree
+#define QCREQ_T_FLOAT	0
+#define QCREQ_T_VECTOR	1
+#define QCREQ_T_STRING	2
+#define QCREQ_T_ENTITY	3
+#define QCREQ_T_INT		4
+
+// wire type codes (FTE etype convention; mvdsv's own etype_t lacks ev_integer)
+#define QCREQ_EV_INTEGER	8
+
+/*
+===================
+SV_ReadQCRequest
+
+Parses a clcfte_qcrequest (client CSQC sendevent) message and dispatches
+to the game: PR2 -> GAME_QCREQUEST export, PR1 -> CSEv_* function.
+
+Wire layout (client->server, matches the client-side writer):
+  for each arg: [byte type] [value]
+    ev_float   -> float
+    ev_vector  -> 3 floats
+    ev_integer -> long
+    ev_entity  -> short (entity number)
+    ev_string  -> string
+  then [string eventname]
+===================
+*/
+static void SV_ReadQCRequest(void)
+{
+	char args[8];
+	char *rname;
+	int i;
+	int argtypes = 0;
+	// scratch strings for the mod (PR2: written into VM data area)
+	static char strbuf[6][64];
+#ifdef USE_PR2
+	unsigned int vm_str_off = 0;
+	qbool vm_str_armed = false;
+#endif
+
+	if (!sv_client)
+		return;
+
+	// qcrequest only makes sense for a game with a VM loaded
+	if (!sv_vm && !progs)
+	{
+		msg_badread = true;
+		return;
+	}
+
+	for (i = 0; i < 6; i++)
+	{
+		int ev = MSG_ReadByte();
+		if (ev == -1)
+		{
+			msg_badread = true;
+			return;
+		}
+
+		switch (ev)
+		{
+		case ev_void:
+			goto done;
+		case ev_float:
+			args[i] = 'f';
+			(&PR_GLOBAL(parm1))[i*3 + 0] = MSG_ReadFloat();
+			argtypes |= QCREQ_T_FLOAT << (i * 3);
+			break;
+		case ev_vector:
+			args[i] = 'v';
+			(&PR_GLOBAL(parm1))[i*3 + 0] = MSG_ReadFloat();
+			(&PR_GLOBAL(parm1))[i*3 + 1] = MSG_ReadFloat();
+			(&PR_GLOBAL(parm1))[i*3 + 2] = MSG_ReadFloat();
+			argtypes |= QCREQ_T_VECTOR << (i * 3);
+			break;
+		case QCREQ_EV_INTEGER:
+			args[i] = 'i';
+			((int *)&PR_GLOBAL(parm1))[i*3 + 0] = MSG_ReadLong();
+			argtypes |= QCREQ_T_INT << (i * 3);
+			break;
+		case ev_entity:
+			{
+				int e = (short)MSG_ReadShort();
+				if (e < 0 || e >= sv.num_edicts)
+				{
+					Con_Printf("client %s sent invalid entity in qcrequest\n", sv_client->name);
+					sv_client->drop = true;
+					return;
+				}
+				((int *)&PR_GLOBAL(parm1))[i*3 + 0] = EDICT_TO_PROG(&sv.edicts[e]);
+				args[i] = 'e';
+				argtypes |= QCREQ_T_ENTITY << (i * 3);
+			}
+			break;
+		case ev_string:
+			{
+				char *s = MSG_ReadString();
+				args[i] = 's';
+				strlcpy(strbuf[i], s, sizeof(strbuf[i]));
+#ifdef USE_PR2
+				if (sv_vm && sv_vm->type != VMI_NATIVE)
+				{	// qvm: write into VM data scratch, store the offset
+					size_t len = strlen(strbuf[i]) + 1;
+					if (!vm_str_armed)
+					{
+						vm_str_off = sv_vm->exactDataLength;
+						vm_str_armed = true;
+					}
+					if (vm_str_off + len > sv_vm->dataLength)
+						break;
+					memcpy(sv_vm->dataBase + vm_str_off, strbuf[i], len);
+					((int *)&PR_GLOBAL(parm1))[i*3 + 0] = vm_str_off;
+					vm_str_off += len;
+				}
+				else
+#endif
+				{
+					((int *)&PR_GLOBAL(parm1))[i*3 + 0] = (intptr_t)strbuf[i];
+				}
+				argtypes |= QCREQ_T_STRING << (i * 3);
+			}
+			break;
+		default:
+			msg_badread = true;
+			return;
+		}
+	}
+
+done:
+	args[i] = 0;
+	rname = MSG_ReadString();
+	if (msg_badread)
+		return;
+
+	if (sv_vm)
+	{	// PR2: fixed export
+		PR2_QCRequest(sv_client->edict, rname, i, argtypes, vm_str_off);
+	}
+	else
+	{	// PR1: lookup CSEv_<name>_<args>
+		extern func_t ED_FindFunctionOffset (char *name);
+		char fname[128];
+		func_t f;
+
+		snprintf(fname, sizeof(fname), "CSEv_%s_%s", rname, args);
+		f = ED_FindFunctionOffset(fname);
+		if (!f && i == 0)
+		{
+			snprintf(fname, sizeof(fname), "CSEv_%s", rname);
+			f = ED_FindFunctionOffset(fname);
+		}
+		if (!f)
+		{
+			SV_ClientPrintf(sv_client, PRINT_HIGH, "qcrequest \"%s\" not supported\n", rname);
+			return;
+		}
+		pr_global_struct->self = EDICT_TO_PROG(sv_client->edict);
+		PR_ExecuteProgram(f);
+	}
+}
+#endif
+
 /*
 ===================
 SV_ExecuteClientMessage
@@ -4825,6 +4991,18 @@ void SV_ExecuteClientMessage (client_t *cl)
 #ifdef FTE_PEXT2_VOICECHAT
 		case clc_voicechat:
 			SV_VoiceReadPacket();
+			break;
+#endif
+
+#ifdef FTE_PEXT_CSQC
+		case clcfte_qcrequest:
+			if (!(cl->fteprotocolextensions & FTE_PEXT_CSQC))
+			{
+				Con_Printf("client %s sent qcrequest without CSQC extension\n", cl->name);
+				SV_DropClient(cl);
+				return;
+			}
+			SV_ReadQCRequest();
 			break;
 #endif
 		}

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -4508,8 +4508,10 @@ static void SV_DebugServerSideWeaponScript(client_t* cl, int best_impulse)
 ===================
 SV_ReadQCRequest
 
-Parses a clcfte_qcrequest (client CSQC sendevent) message and dispatches
-to the game: PR2 -> GAME_QCREQUEST export, PR1 -> CSEv_* function.
+Parses a clcfte_qcrequest (client CSQC sendevent) message and stores it for
+the game: PR2 -> GAME_QCREQUEST export (the mod fetches the event name via
+trap_Argv(0) and typed arg values via the qcrequestarg trap), PR1 -> CSEv_*
+function.
 
 Wire layout (client->server, matches the FTE csqc writer PF_cs_sendevent):
   for each arg: [byte type] [value]
@@ -4517,7 +4519,7 @@ Wire layout (client->server, matches the FTE csqc writer PF_cs_sendevent):
     ev_float    -> float
     ev_vector   -> 3 floats
     ev_integer  -> long
-    ev_uint     -> long (consumed; PR2 has no unsigned slot)
+    ev_uint     -> long (delivered as int)
     ev_int64/ev_uint64/ev_double -> 8 bytes (consumed)
     ev_entity   -> short (entity number)
     ev_string   -> string
@@ -4526,8 +4528,89 @@ Wire layout (client->server, matches the FTE csqc writer PF_cs_sendevent):
   an optional [200+seat] marker byte may precede the terminator
   then [0 terminator] then [string eventname]
 Unknown/unsupported arg types are consumed (never msg_badread on the type
-itself) so the client is not kicked; such args are tagged UNKNOWN (5) in
-argtypes and carry no usable value in the parm slots.
+itself) so the client is not kicked; such args are stored as UNKNOWN (5)
+and carry no usable value.
+===================
+*/
+
+// one parsed qcrequest argument; values are delivered to the mod by SV_QCRequestArg
+typedef struct
+{
+	int		type;		// QCREQ_T_*
+	float	f[3];		// float (f[0]) / vector (f[0..2])
+	int		i;			// int / uint / entity (EDICT_TO_PROG value)
+	char	s[64];		// string
+} qcrequest_arg_t;
+
+// state of the qcrequest currently being dispatched; valid only during the
+// GAME_QCREQUEST call / PR1 CSEv_* execute
+static qcrequest_arg_t qcrequest_args[6];
+static int qcrequest_argc;
+static char qcrequest_eventname[128];
+
+/*
+===================
+SV_QCRequestName
+
+Returns the event name of the qcrequest currently being dispatched.
+===================
+*/
+const char *SV_QCRequestName(void)
+{
+	return qcrequest_eventname;
+}
+
+/*
+===================
+SV_QCRequestArg
+
+Copies argument idx into dst (up to dstsize bytes) and returns its type
+(QCREQ_T_*); returns -1 for an out-of-range index or NULL dst. Strings are
+copied null-terminated; UNKNOWN args report their type but copy nothing.
+===================
+*/
+int SV_QCRequestArg(int idx, void *dst, size_t dstsize)
+{
+	qcrequest_arg_t *a;
+	const void *src;
+	int size;
+
+	if (idx < 0 || idx >= qcrequest_argc || !dst)
+		return -1;
+
+	a = &qcrequest_args[idx];
+
+	switch (a->type)
+	{
+	case QCREQ_T_STRING:
+		strlcpy(dst, a->s, dstsize);
+		return QCREQ_T_STRING;
+	case QCREQ_T_VECTOR:
+		src = &a->f[0];
+		size = 12;
+		break;
+	case QCREQ_T_FLOAT:
+		src = &a->f[0];
+		size = 4;
+		break;
+	case QCREQ_T_INT:
+	case QCREQ_T_ENTITY:
+		src = &a->i;
+		size = 4;
+		break;
+	default:
+		return QCREQ_T_UNKNOWN;	// no usable value
+	}
+
+	if ((size_t)size > dstsize)
+		return a->type;	// buffer too small: still report the type
+	memcpy(dst, src, size);
+	return a->type;
+}
+
+/*
+===================
+SV_ReadQCRequest
 ===================
 */
 static void SV_ReadQCRequest(void)
@@ -4535,13 +4618,6 @@ static void SV_ReadQCRequest(void)
 	char args[8];
 	char *rname;
 	int i;
-	int argtypes = 0;
-	// scratch strings for the mod (PR2: written into VM data area)
-	static char strbuf[6][64];
-#ifdef USE_PR2
-	unsigned int vm_str_off = 0;
-	qbool vm_str_armed = false;
-#endif
 
 	if (!sv_client)
 		return;
@@ -4553,7 +4629,7 @@ static void SV_ReadQCRequest(void)
 		return;
 	}
 
-	for (i = 0; i < 6; i++)
+	for (i = 0; ; i++)
 	{
 		int ev = MSG_ReadByte();
 		if (ev == -1)
@@ -4563,7 +4639,20 @@ static void SV_ReadQCRequest(void)
 		}
 
 		if (ev >= 200)
-			continue;	// fte split-screen seat marker: ignore (mvdsv has no csqc seats)
+		{	// fte split-screen seat marker: does not consume an arg slot
+			i--;
+			continue;
+		}
+
+		if (i >= 6)
+		{	// the client sends at most 6 args; anything further must be the terminator
+			if (ev != ev_void)
+			{
+				msg_badread = true;
+				return;
+			}
+			goto done;
+		}
 
 		switch (ev)
 		{
@@ -4571,30 +4660,31 @@ static void SV_ReadQCRequest(void)
 			goto done;
 		case ev_float:
 			args[i] = 'f';
-			(&PR_GLOBAL(parm1))[i*3 + 0] = MSG_ReadFloat();
-			argtypes |= QCREQ_T_FLOAT << (i * 3);
+			qcrequest_args[i].type = QCREQ_T_FLOAT;
+			qcrequest_args[i].f[0] = MSG_ReadFloat();
 			break;
 		case ev_vector:
 			args[i] = 'v';
-			(&PR_GLOBAL(parm1))[i*3 + 0] = MSG_ReadFloat();
-			(&PR_GLOBAL(parm1))[i*3 + 1] = MSG_ReadFloat();
-			(&PR_GLOBAL(parm1))[i*3 + 2] = MSG_ReadFloat();
-			argtypes |= QCREQ_T_VECTOR << (i * 3);
+			qcrequest_args[i].type = QCREQ_T_VECTOR;
+			qcrequest_args[i].f[0] = MSG_ReadFloat();
+			qcrequest_args[i].f[1] = MSG_ReadFloat();
+			qcrequest_args[i].f[2] = MSG_ReadFloat();
 			break;
 		case QCREQ_EV_INTEGER:
 			args[i] = 'i';
-			((int *)&PR_GLOBAL(parm1))[i*3 + 0] = MSG_ReadLong();
-			argtypes |= QCREQ_T_INT << (i * 3);
+			qcrequest_args[i].type = QCREQ_T_INT;
+			qcrequest_args[i].i = MSG_ReadLong();
 			break;
 		case QCREQ_EV_UINT:
 			args[i] = 'u';
-			((int *)&PR_GLOBAL(parm1))[i*3 + 0] = MSG_ReadLong();
-			argtypes |= QCREQ_T_INT << (i * 3);
+			qcrequest_args[i].type = QCREQ_T_INT;
+			qcrequest_args[i].i = MSG_ReadLong();
 			break;
 		case QCREQ_EV_INT64:
 		case QCREQ_EV_UINT64:
 		case QCREQ_EV_DOUBLE:
 			args[i] = '?';	// 64-bit/double: no PR2 slot, consume and skip
+			qcrequest_args[i].type = QCREQ_T_UNKNOWN;
 			MSG_ReadByte();	// 8 bytes
 			MSG_ReadByte();
 			MSG_ReadByte();
@@ -4603,19 +4693,18 @@ static void SV_ReadQCRequest(void)
 			MSG_ReadByte();
 			MSG_ReadByte();
 			MSG_ReadByte();
-			argtypes |= QCREQ_T_UNKNOWN << (i * 3);
 			break;
 		case ev_pointer:
 			args[i] = 'p';
+			qcrequest_args[i].type = QCREQ_T_UNKNOWN;	// consumed, no usable value
 			// payload length is carried by the preceding ev_integer arg value
 			if (i > 0 && args[i-1] == 'i')
 			{
-				int len = ((int *)&PR_GLOBAL(parm1))[(i-1)*3 + 0];
+				int len = qcrequest_args[i-1].i;
 				if (len < 0 || len > (1 << 16))
-					break;	// nonsense length: cannot realign, stop parsing args
+					break;	// nonsense length: cannot realign
 				while (len-- > 0)
 					MSG_ReadByte();
-				argtypes |= QCREQ_T_UNKNOWN << (i * 3);	// consumed, no PR2 slot
 			}
 			break;
 		case ev_entity:
@@ -4627,61 +4716,44 @@ static void SV_ReadQCRequest(void)
 					sv_client->drop = true;
 					return;
 				}
-				((int *)&PR_GLOBAL(parm1))[i*3 + 0] = EDICT_TO_PROG(&sv.edicts[e]);
 				args[i] = 'e';
-				argtypes |= QCREQ_T_ENTITY << (i * 3);
+				qcrequest_args[i].type = QCREQ_T_ENTITY;
+				qcrequest_args[i].i = EDICT_TO_PROG(&sv.edicts[e]);
 			}
 			break;
 		case ev_string:
-			{
-				char *s = MSG_ReadString();
-				args[i] = 's';
-				strlcpy(strbuf[i], s, sizeof(strbuf[i]));
-#ifdef USE_PR2
-				if (sv_vm && sv_vm->type != VMI_NATIVE)
-				{	// qvm: write into VM data scratch, store the offset
-					size_t len = strlen(strbuf[i]) + 1;
-					if (!vm_str_armed)
-					{
-						vm_str_off = sv_vm->exactDataLength;
-						vm_str_armed = true;
-					}
-					if (vm_str_off + len > sv_vm->dataLength)
-						break;
-					memcpy(sv_vm->dataBase + vm_str_off, strbuf[i], len);
-					((int *)&PR_GLOBAL(parm1))[i*3 + 0] = vm_str_off;
-					vm_str_off += len;
-				}
-				else
-#endif
-				{
-					((int *)&PR_GLOBAL(parm1))[i*3 + 0] = (intptr_t)strbuf[i];
-				}
-				argtypes |= QCREQ_T_STRING << (i * 3);
-			}
+			args[i] = 's';
+			qcrequest_args[i].type = QCREQ_T_STRING;
+			strlcpy(qcrequest_args[i].s, MSG_ReadString(), sizeof(qcrequest_args[i].s));
 			break;
 		default:
 			// unknown wire type: don't kick the client, consume it as a long
 			// (FTE fallback width) and tag the arg UNKNOWN
 			args[i] = '?';
+			qcrequest_args[i].type = QCREQ_T_UNKNOWN;
 			MSG_ReadLong();
-			argtypes |= QCREQ_T_UNKNOWN << (i * 3);
 			break;
 		}
 	}
 
 done:
 	args[i] = 0;
+	qcrequest_argc = i;
 	rname = MSG_ReadString();
 	if (msg_badread)
 		return;
 
+	strlcpy(qcrequest_eventname, rname, sizeof(qcrequest_eventname));
+
 	if (sv_vm)
-	{	// PR2: fixed export
-		PR2_QCRequest(sv_client->edict, rname, i, argtypes, vm_str_off);
+	{	// PR2: fixed export. self=client, arg0=argcount; the mod pulls the
+		// event name via trap_Argv(0) and arg values via the qcrequestarg trap.
+		PR2_QCRequest(sv_client->edict, qcrequest_argc);
 	}
 	else
 	{	// PR1: lookup CSEv_<name>_<args>
+		// NOTE (Package B): PR1 argument delivery (parm slots / temp-strings)
+		// is not implemented yet - CSQC is gated off for PR1 mods.
 		extern func_t ED_FindFunctionOffset (char *name);
 		char fname[128];
 		func_t f;

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -4487,6 +4487,7 @@ static void SV_DebugServerSideWeaponScript(client_t* cl, int best_impulse)
 #define QCREQ_T_STRING	2
 #define QCREQ_T_ENTITY	3
 #define QCREQ_T_INT		4
+#define QCREQ_T_UNKNOWN	5	// wire type consumed, but no usable value delivered
 
 // wire type codes (FTE etype convention; mvdsv's own etype_t lacks the
 // extended integer/pointer types). Consumed by width so a client using the
@@ -4519,8 +4520,8 @@ Wire layout (client->server, matches the FTE csqc writer PF_cs_sendevent):
   an optional [200+seat] marker byte may precede the terminator
   then [0 terminator] then [string eventname]
 Unknown/unsupported arg types are consumed (never msg_badread on the type
-itself) so the client is not kicked; such args are delivered as '?' with no
-argtypes bits set.
+itself) so the client is not kicked; such args are tagged UNKNOWN (5) in
+argtypes and carry no usable value in the parm slots.
 ===================
 */
 static void SV_ReadQCRequest(void)
@@ -4596,6 +4597,7 @@ static void SV_ReadQCRequest(void)
 			MSG_ReadByte();
 			MSG_ReadByte();
 			MSG_ReadByte();
+			argtypes |= QCREQ_T_UNKNOWN << (i * 3);
 			break;
 		case ev_pointer:
 			args[i] = 'p';
@@ -4607,6 +4609,7 @@ static void SV_ReadQCRequest(void)
 					break;	// nonsense length: cannot realign, stop parsing args
 				while (len-- > 0)
 					MSG_ReadByte();
+				argtypes |= QCREQ_T_UNKNOWN << (i * 3);	// consumed, no PR2 slot
 			}
 			break;
 		case ev_entity:
@@ -4653,9 +4656,10 @@ static void SV_ReadQCRequest(void)
 			break;
 		default:
 			// unknown wire type: don't kick the client, consume it as a long
-			// (FTE fallback width) and mark the arg as unsupported
+			// (FTE fallback width) and tag the arg UNKNOWN
 			args[i] = '?';
 			MSG_ReadLong();
+			argtypes |= QCREQ_T_UNKNOWN << (i * 3);
 			break;
 		}
 	}

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -4959,7 +4959,7 @@ void SV_ExecuteClientMessage (client_t *cl)
 			// last one we sent, some packets were lost - flag all CSQC ents
 			// the client already has for a full resend (simplified NACK).
 			// TODO (F8): heuristic is unverified under packet loss - add the
-			// loss scenario from mvdsv_csqc_steps.md Phase 8 and only tune it
+			// loss scenario from docs/mvdsv_csqc_plan.md (sec. 5/6) and only tune it
 			// against measured results before changing it.
 			if (cl->pendingcsqcbits &&
 				cl->delta_sequence != -1 &&

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -3118,7 +3118,16 @@ void SV_Voice_UnmuteAll_f(void)
 #ifdef FTE_PEXT_CSQC
 void SV_EnableClientsCSQC(void)
 {
+	int e;
+
 	sv_client->csqcactive = true;
+
+	// the client just (re)enabled csqc: resend all entities it already has
+	// so its freshly-loaded csprogs gets the full state.
+	if (sv_client->pendingcsqcbits)
+		for (e = 1; e < sv_client->max_net_ents; e++)
+			if (sv_client->pendingcsqcbits[e] & SENDFLAGS_PRESENT)
+				sv_client->pendingcsqcbits[e] |= SENDFLAGS_USABLE;
 }
 
 void SV_DisableClientsCSQC(void)
@@ -4634,6 +4643,20 @@ void SV_ExecuteClientMessage (client_t *cl)
 			break;
 
 		case clc_delta:
+#ifdef FTE_PEXT_CSQC
+			// if the client asks for a delta from an older sequence than the
+			// last one we sent, some packets were lost - flag all CSQC ents
+			// the client already has for a full resend (simplified NACK).
+			if (cl->pendingcsqcbits &&
+				cl->delta_sequence != -1 &&
+				(unsigned int)cl->delta_sequence < (unsigned int)cl->netchan.outgoing_sequence)
+			{
+				int e;
+				for (e = 1; e < cl->max_net_ents; e++)
+					if (cl->pendingcsqcbits[e] & SENDFLAGS_PRESENT)
+						cl->pendingcsqcbits[e] |= SENDFLAGS_USABLE;
+			}
+#endif
 			cl->delta_sequence = MSG_ReadByte ();
 			break;
 

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -3126,6 +3126,11 @@ void SV_EnableClientsCSQC(void)
 	if (!SV_CSQCActive())
 		return; // PR1 mod: no CSQC support, ignore the client request
 
+	// a client that never negotiated FTE_PEXT_CSQC must not be enabled - svc 76
+	// would be sent to a client that Host_Errors on it (PR228 rev [17]).
+	if (!(sv_client->fteprotocolextensions & FTE_PEXT_CSQC))
+		return;
+
 	sv_client->csqcactive = true;
 
 	// the client just (re)enabled csqc: resend all entities it already has
@@ -4487,7 +4492,8 @@ static void SV_DebugServerSideWeaponScript(client_t* cl, int best_impulse)
 #endif
 
 #ifdef FTE_PEXT_CSQC
-// sendevent type codes (design doc ezquake_csqc_pr2.md §5.2); engine and mod must agree
+// sendevent argument value type codes delivered to the mod via qcrequestarg;
+// engine and mod must agree on these values.
 #define QCREQ_T_FLOAT	0
 #define QCREQ_T_VECTOR	1
 #define QCREQ_T_STRING	2
@@ -4497,7 +4503,7 @@ static void SV_DebugServerSideWeaponScript(client_t* cl, int best_impulse)
 
 // wire type codes (FTE etype convention; mvdsv's own etype_t lacks the
 // extended integer/pointer types). Consumed by width so a client using the
-// richer FTE types is not dropped (F9).
+// richer FTE types is not dropped.
 #define QCREQ_EV_INTEGER	8
 #define QCREQ_EV_UINT		9
 #define QCREQ_EV_INT64		10
@@ -4509,9 +4515,9 @@ static void SV_DebugServerSideWeaponScript(client_t* cl, int best_impulse)
 SV_ReadQCRequest
 
 Parses a clcfte_qcrequest (client CSQC sendevent) message and stores it for
-the game: PR2 -> GAME_QCREQUEST export (the mod fetches the event name via
-trap_Argv(0) and typed arg values via the qcrequestarg trap), PR1 -> CSEv_*
-function.
+the game: on a PR2 VM it is dispatched to the GAME_QCREQUEST export (the mod
+fetches the event name via trap_Argv(0) and typed arg values via the
+qcrequestarg trap).
 
 Wire layout (client->server, matches the FTE csqc writer PF_cs_sendevent):
   for each arg: [byte type] [value]
@@ -4543,7 +4549,7 @@ typedef struct
 } qcrequest_arg_t;
 
 // state of the qcrequest currently being dispatched; valid only during the
-// GAME_QCREQUEST call / PR1 CSEv_* execute
+// GAME_QCREQUEST call.
 static qcrequest_arg_t qcrequest_args[6];
 static int qcrequest_argc;
 static char qcrequest_eventname[128];
@@ -4614,9 +4620,10 @@ SV_ReadQCRequest
 
 Parses (and optionally dispatches) a clcfte_qcrequest. When `dispatch` is
 false the wire payload is still fully consumed (typed args + event name) but
-no mod export / PR1 CSEv_* is invoked - used to safely swallow a sendevent
-on a server whose loaded mod is PR1 (no CSQC) so the bytes are not re-parsed
-as clc opcodes (PR228 rev [6]).
+no mod export is invoked - used to safely swallow a sendevent on a server
+whose loaded mod is PR1 (no CSQC) so the bytes are not re-parsed as clc
+opcodes (PR228 rev [6]). Dispatch (true) always means a PR2 VM, so only
+GAME_QCREQUEST is reached (PR228 rev [20]).
 ===================
 */
 static void SV_ReadQCRequest(qbool dispatch)
@@ -4691,14 +4698,7 @@ static void SV_ReadQCRequest(qbool dispatch)
 		case QCREQ_EV_DOUBLE:
 			args[i] = '?';	// 64-bit/double: no PR2 slot, consume and skip
 			qcrequest_args[i].type = QCREQ_T_UNKNOWN;
-			MSG_ReadByte();	// 8 bytes
-			MSG_ReadByte();
-			MSG_ReadByte();
-			MSG_ReadByte();
-			MSG_ReadByte();
-			MSG_ReadByte();
-			MSG_ReadByte();
-			MSG_ReadByte();
+			MSG_ReadSkip(8);	// 8 bytes; stops itself on badread (PR228 rev [19])
 			break;
 		case ev_pointer:
 			args[i] = 'p';
@@ -4714,8 +4714,7 @@ static void SV_ReadQCRequest(qbool dispatch)
 					msg_badread = true;
 					return;
 				}
-				while (len-- > 0)
-					MSG_ReadByte();
+				MSG_ReadSkip(len);	// stops itself on badread (PR228 rev [19])
 			}
 			else
 			{
@@ -4769,34 +4768,12 @@ done:
 	if (!dispatch)
 		return;	// consumed the payload only (e.g. PR1 mod: CSQC off)
 
-	if (sv_vm)
-	{	// PR2: fixed export. self=client, arg0=argcount; the mod pulls the
-		// event name via trap_Argv(0) and arg values via the qcrequestarg trap.
-		PR2_QCRequest(sv_client->edict, qcrequest_argc);
-	}
-	else
-	{	// PR1: lookup CSEv_<name>_<args>
-		// NOTE (Package B): PR1 argument delivery (parm slots / temp-strings)
-		// is not implemented yet - CSQC is gated off for PR1 mods.
-		extern func_t ED_FindFunctionOffset (char *name);
-		char fname[128];
-		func_t f;
-
-		snprintf(fname, sizeof(fname), "CSEv_%s_%s", rname, args);
-		f = ED_FindFunctionOffset(fname);
-		if (!f && i == 0)
-		{
-			snprintf(fname, sizeof(fname), "CSEv_%s", rname);
-			f = ED_FindFunctionOffset(fname);
-		}
-		if (!f)
-		{
-			SV_ClientPrintf(sv_client, PRINT_HIGH, "qcrequest \"%s\" not supported\n", rname);
-			return;
-		}
-		pr_global_struct->self = EDICT_TO_PROG(sv_client->edict);
-		PR_ExecuteProgram(f);
-	}
+	// PR2: fixed export. self=client, arg0=argcount; the mod pulls the event
+	// name via trap_Argv(0) and arg values via the qcrequestarg trap. The PR1
+	// CSEv_* branch was unreachable here - dispatch is only true when
+	// SV_CSQCActive() (sv_vm != NULL), PR1 calls come with dispatch=false and
+	// return above (PR228 rev [20]).
+	PR2_QCRequest(sv_client->edict, qcrequest_argc);
 }
 #endif
 

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -4752,6 +4752,9 @@ static void SV_ReadQCRequest(qbool dispatch)
 			MSG_ReadLong();
 			break;
 		}
+
+		if (msg_badread)
+			return;	// stream ended mid-argument (PR228 rev [12])
 	}
 
 done:

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -3127,7 +3127,7 @@ void SV_EnableClientsCSQC(void)
 		return; // PR1 mod: no CSQC support, ignore the client request
 
 	// a client that never negotiated FTE_PEXT_CSQC must not be enabled - svc 76
-	// would be sent to a client that Host_Errors on it (PR228 rev [17]).
+	// would be sent to a client that Host_Errors on it.
 	if (!(sv_client->fteprotocolextensions & FTE_PEXT_CSQC))
 		return;
 
@@ -3135,7 +3135,7 @@ void SV_EnableClientsCSQC(void)
 
 	// arm the CSQC delta bitset now: SV_WriteEntitiesToClient would allocate it
 	// lazily a frame later, and sendflags set this frame would be dropped in the
-	// meantime (PR228 rev [9]).
+	// meantime.
 	if (!sv_client->pendingcsqcbits && sv.max_edicts > 0)
 	{
 		sv_client->pendingcsqcbits = Q_calloc(sv.max_edicts, sizeof(uint64_t));
@@ -4631,8 +4631,8 @@ Parses (and optionally dispatches) a clcfte_qcrequest. When `dispatch` is
 false the wire payload is still fully consumed (typed args + event name) but
 no mod export is invoked - used to safely swallow a sendevent on a server
 whose loaded mod is PR1 (no CSQC) so the bytes are not re-parsed as clc
-opcodes (PR228 rev [6]). Dispatch (true) always means a PR2 VM, so only
-GAME_QCREQUEST is reached (PR228 rev [20]).
+opcodes. Dispatch (true) always means a PR2 VM, so only
+GAME_QCREQUEST is reached.
 ===================
 */
 static void SV_ReadQCRequest(qbool dispatch)
@@ -4707,7 +4707,7 @@ static void SV_ReadQCRequest(qbool dispatch)
 		case QCREQ_EV_DOUBLE:
 			args[i] = '?';	// 64-bit/double: no PR2 slot, consume and skip
 			qcrequest_args[i].type = QCREQ_T_UNKNOWN;
-			MSG_ReadSkip(8);	// 8 bytes; stops itself on badread (PR228 rev [19])
+			MSG_ReadSkip(8);	// 8 bytes; stops itself on badread
 			break;
 		case ev_pointer:
 			args[i] = 'p';
@@ -4723,7 +4723,7 @@ static void SV_ReadQCRequest(qbool dispatch)
 					msg_badread = true;
 					return;
 				}
-				MSG_ReadSkip(len);	// stops itself on badread (PR228 rev [19])
+				MSG_ReadSkip(len);	// stops itself on badread
 			}
 			else
 			{
@@ -4762,7 +4762,7 @@ static void SV_ReadQCRequest(qbool dispatch)
 		}
 
 		if (msg_badread)
-			return;	// stream ended mid-argument (PR228 rev [12])
+			return;	// stream ended mid-argument
 	}
 
 done:
@@ -4781,7 +4781,7 @@ done:
 	// name via trap_Argv(0) and arg values via the qcrequestarg trap. The PR1
 	// CSEv_* branch was unreachable here - dispatch is only true when
 	// SV_CSQCActive() (sv_vm != NULL), PR1 calls come with dispatch=false and
-	// return above (PR228 rev [20]).
+	// return above.
 	PR2_QCRequest(sv_client->edict, qcrequest_argc);
 }
 #endif
@@ -5137,7 +5137,7 @@ void SV_ExecuteClientMessage (client_t *cl)
 			{
 				// PR1 mod: CSQC is disabled, but the payload must still be
 				// consumed or its bytes would re-parse as clc opcodes below
-				// (PR228 rev [6]). Swallow without dispatching.
+				// Swallow without dispatching.
 				Con_DPrintf("client %s sent qcrequest but the loaded mod is PR1 (no CSQC)\n", cl->name);
 				SV_ReadQCRequest(false);
 				break;

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -3133,6 +3133,15 @@ void SV_EnableClientsCSQC(void)
 
 	sv_client->csqcactive = true;
 
+	// arm the CSQC delta bitset now: SV_WriteEntitiesToClient would allocate it
+	// lazily a frame later, and sendflags set this frame would be dropped in the
+	// meantime (PR228 rev [9]).
+	if (!sv_client->pendingcsqcbits && sv.max_edicts > 0)
+	{
+		sv_client->pendingcsqcbits = Q_calloc(sv.max_edicts, sizeof(uint64_t));
+		sv_client->max_net_ents = sv.max_edicts;
+	}
+
 	// the client just (re)enabled csqc: resend all entities it already has
 	// so its freshly-loaded csprogs gets the full state.
 	if (sv_client->pendingcsqcbits)

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -4611,9 +4611,15 @@ int SV_QCRequestArg(int idx, void *dst, size_t dstsize)
 /*
 ===================
 SV_ReadQCRequest
+
+Parses (and optionally dispatches) a clcfte_qcrequest. When `dispatch` is
+false the wire payload is still fully consumed (typed args + event name) but
+no mod export / PR1 CSEv_* is invoked - used to safely swallow a sendevent
+on a server whose loaded mod is PR1 (no CSQC) so the bytes are not re-parsed
+as clc opcodes (PR228 rev [6]).
 ===================
 */
-static void SV_ReadQCRequest(void)
+static void SV_ReadQCRequest(qbool dispatch)
 {
 	char args[8];
 	char *rname;
@@ -4756,6 +4762,9 @@ done:
 		return;
 
 	strlcpy(qcrequest_eventname, rname, sizeof(qcrequest_eventname));
+
+	if (!dispatch)
+		return;	// consumed the payload only (e.g. PR1 mod: CSQC off)
 
 	if (sv_vm)
 	{	// PR2: fixed export. self=client, arg0=argcount; the mod pulls the
@@ -5144,19 +5153,24 @@ void SV_ExecuteClientMessage (client_t *cl)
 
 #ifdef FTE_PEXT_CSQC
 		case clcfte_qcrequest:
-			if (!SV_CSQCActive())
-			{
-				// PR1 mod: CSQC is disabled, ignore the sendevent instead of dropping
-				Con_DPrintf("client %s sent qcrequest but the loaded mod is PR1 (no CSQC)\n", cl->name);
-				break;
-			}
+			// A client that never negotiated FTE_PEXT_CSQC must not reach this
+			// path at all - 81 (clcfte_qcrequest) only makes sense with CSQC.
 			if (!(cl->fteprotocolextensions & FTE_PEXT_CSQC))
 			{
 				Con_Printf("client %s sent qcrequest without CSQC extension\n", cl->name);
 				SV_DropClient(cl);
 				return;
 			}
-			SV_ReadQCRequest();
+			if (!SV_CSQCActive())
+			{
+				// PR1 mod: CSQC is disabled, but the payload must still be
+				// consumed or its bytes would re-parse as clc opcodes below
+				// (PR228 rev [6]). Swallow without dispatching.
+				Con_DPrintf("client %s sent qcrequest but the loaded mod is PR1 (no CSQC)\n", cl->name);
+				SV_ReadQCRequest(false);
+				break;
+			}
+			SV_ReadQCRequest(true);
 			break;
 #endif
 		}

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -904,6 +904,21 @@ static void Cmd_Spawn_f (void)
 	//
 	memset (sv_client->stats, 0, sizeof(sv_client->stats));
 
+#ifdef FTE_PEXT_CSQC
+	// CSQC float/string stat caches are per-level too: free the host string
+	// copies and clear the float cache so a fresh signon (map change / respawn)
+	// re-sends them. The client shuts CSQC down on map change and reloads
+	// csprogs, so unchanged values must be re-emitted; otherwise stale host
+	// copies would also leak.
+	{
+		int si;
+
+		memset (sv_client->statsf, 0, sizeof(sv_client->statsf));
+		for (si = 0; si < MAX_CL_STATS; si++)
+			Q_free (sv_client->statss[si]);
+	}
+#endif
+
 	ClientReliableWrite_Begin (sv_client, svc_updatestatlong, 6);
 	ClientReliableWrite_Byte (sv_client, STAT_TOTALSECRETS);
 	ClientReliableWrite_Long (sv_client, PR_GLOBAL(total_secrets));
@@ -4739,6 +4754,10 @@ static void SV_ReadQCRequest(qbool dispatch)
 				if (e < 0 || e >= sv.num_edicts)
 				{
 					Con_Printf("client %s sent invalid entity in qcrequest\n", sv_client->name);
+					// do not leave the rest of the qcrequest (args + event name)
+					// to be re-parsed as clc opcodes: mark badread so the caller
+					// drops the client at the top of the parse loop.
+					msg_badread = true;
 					sv_client->drop = true;
 					return;
 				}
@@ -5125,6 +5144,16 @@ void SV_ExecuteClientMessage (client_t *cl)
 
 #ifdef FTE_PEXT_CSQC
 		case clcfte_qcrequest:
+			if (!SV_CSQCActive())
+			{
+				// PR1 mod (or CSQC not loaded): the payload must still be
+				// consumed or its bytes would re-parse as clc opcodes below.
+				// Swallow without dispatching, even for a client that still
+				// carries FTE_PEXT_CSQC from the PR2 map it connected on.
+				Con_DPrintf("client %s sent qcrequest but CSQC is not active\n", cl->name);
+				SV_ReadQCRequest(false);
+				break;
+			}
 			// A client that never negotiated FTE_PEXT_CSQC must not reach this
 			// path at all - 81 (clcfte_qcrequest) only makes sense with CSQC.
 			if (!(cl->fteprotocolextensions & FTE_PEXT_CSQC))
@@ -5132,15 +5161,6 @@ void SV_ExecuteClientMessage (client_t *cl)
 				Con_Printf("client %s sent qcrequest without CSQC extension\n", cl->name);
 				SV_DropClient(cl);
 				return;
-			}
-			if (!SV_CSQCActive())
-			{
-				// PR1 mod: CSQC is disabled, but the payload must still be
-				// consumed or its bytes would re-parse as clc opcodes below
-				// Swallow without dispatching.
-				Con_DPrintf("client %s sent qcrequest but the loaded mod is PR1 (no CSQC)\n", cl->name);
-				SV_ReadQCRequest(false);
-				break;
 			}
 			SV_ReadQCRequest(true);
 			break;

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -4966,23 +4966,6 @@ void SV_ExecuteClientMessage (client_t *cl)
 			break;
 
 		case clc_delta:
-#ifdef FTE_PEXT_CSQC
-			// if the client asks for a delta from an older sequence than the
-			// last one we sent, some packets were lost - flag all CSQC ents
-			// the client already has for a full resend (simplified NACK).
-			// TODO (F8): heuristic is unverified under packet loss - add the
-			// loss scenario from docs/mvdsv_csqc_plan.md (sec. 5/6) and only tune it
-			// against measured results before changing it.
-			if (cl->pendingcsqcbits &&
-				cl->delta_sequence != -1 &&
-				(unsigned int)cl->delta_sequence < (unsigned int)cl->netchan.outgoing_sequence)
-			{
-				int e;
-				for (e = 1; e < cl->max_net_ents; e++)
-					if (cl->pendingcsqcbits[e] & SENDFLAGS_PRESENT)
-						cl->pendingcsqcbits[e] |= SENDFLAGS_USABLE;
-			}
-#endif
 			cl->delta_sequence = MSG_ReadByte ();
 			break;
 
@@ -5183,6 +5166,12 @@ void SV_ExecuteClientMessage (client_t *cl)
 	if (antilag_players_present && sv_debug_antilag.value) {
 		SV_DebugWriteServerAntilagPositions(cl, antilag_players_present);
 	}
+#endif
+
+#ifdef FTE_PEXT_CSQC
+	// frames this packet implicitly acknowledges are not lost (FTE sv_user.c,
+	// after the clc parse loop)
+	SV_AckEntityFrame (cl, cl->netchan.incoming_acknowledged);
 #endif
 }
 


### PR DESCRIPTION
## Summary

Implements server-side CSQC support for PR2 mods (native/QVM) on mvdsv,
following the FTE `ext_csqc_1.txt` model: the server advertises
`FTE_PEXT_CSQC`, serves `*csprogs*` keys, delta-emits CSQC entities from a
per-client `pendingcsqcbits[]` state, forwards `clientstat`/`globalstat`/
`pointerstat`/`setsendneeded` to stats 32–127, and dispatches client
`sendevent`s (`clcfte_qcrequest`) to the mod.

Scope: PR2 path only. PR1 (`progs.dat`) stays gated off — the CSQC gate
(`SV_CSQCActive()` = `sv_vm != NULL`) is kept until a separate PR1 package
is implemented (classic .dat emission via `SendEntity` field + legacy
`WriteDest MSG_CSQC`).

## What's included (phases 0–6 + review fixes F1–F16)

- **Wire/protocol**: `MSG_CSQC`/`MSG_ENTITY`, `SENDFLAGS_*`, `PVSF_NOREMOVE`,
  `svc_fte_csqcentities(_sized)` framing; localizes the CSQC wire message
  numbers (83/90/81) in `server.h` since upstream `qwprot` lacks them.
- **Entity emission**: `SV_EmitCSQCUpdate` (delta vs `pendingcsqcbits[]`,
  `0x8000` remove flag, overflow-tolerant), `SV_ProcessSendFlags`/
  `SV_CleanupEnts` (FTE-style float[3] sendflags packed to 3×24 bits),
  `enablecsqc`/`disablecsqc` full-resend, lazy per-client bitset alloc.
- **Stats 32–127**: `MAX_CL_STATS` 32→128, `SV_UpdateQCStats` in live/MVD/
  initial-gamestate paths, vector stats bounds check.
- **sendevent**: `clcfte_qcrequest` → `SV_ReadQCRequest` → PR2
  `GAME_QCREQUEST` export with a pull-based contract (event name via
  `trap_Argv(0)`, args via the `qcrequestarg` trap); robust parsing
  (unknown/64-bit/pointer arg types consumed instead of dropping the client).
- **PR2 traps**: `clientstat`/`globalstat`/`pointerstat`/`setsendneeded`
  (+ `setsendneeded64` 2×int variant), `WriteDest2` `MSG_CSQC`.
- **MVD recorder + debug**: recorder CSQC support, multicast
  `svc_fte_cgamepacket` filtering, sized (92) variant for live clients under
  `sv_csqcdebug`.

## Notes / design decisions

- `FTE_PEXT_CSQC` is announced per-map and only for PR2 mods
  (`SV_UpdateCSQCExtension`/`SV_LoadCSQC` after `PR_LoadProgs`), not statically.
- `src/qwprot` is pinned to upstream `QW-Group/qwprot` master; the missing
  CSQC message numbers are `#ifndef`-guarded local defines in `server.h`.
- Known protocol conflict (pre-existing): ezQuake's dead `svc_qizmovoice=83`
  collides with FTE `svc_fte_cgamepacket=83`; mvdsv does not send qizmovoice
  and filters the CSQC multicast to `FTE_PEXT_CSQC` clients.

## Testing

- Built native + QVM paths; CSQC client scenarios (spawn/update/remove,
  sendevent, stats) verified per `docs/mvdsv_csqc_steps.md` (Phase 8) on a
  PR2 CSQC mod.
- Non-CSQC clients unaffected (emission only when `enablecsqc`).